### PR TITLE
PR 01: Refactor Java test cases

### DIFF
--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class BuilderTest {
 
     @Test
-    public void testBuild() throws Error.Language, Error.SymbolTableOverlap, Error.FormatError {
+    public void testBuild() throws Error.Language, Error.FormatError {
         SecureRandom rng = new SecureRandom();
         KeyPair root = new KeyPair(rng);
         SymbolTable symbols = Biscuit.default_symbol_table();

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -65,17 +65,17 @@ public class BuilderTest {
 
     @Test
     public void testStringValueOfAStringTerm() {
-        assertEquals( "\"hello\"", new Term.Str("hello").toString() );
+        assertEquals("\"hello\"", new Term.Str("hello").toString());
     }
 
     @Test
     public void testStringValueOfAnIntegerTerm() {
-        assertEquals( "123", new Term.Integer(123).toString() );
+        assertEquals("123", new Term.Integer(123).toString());
     }
 
     @Test
     public void testStringValueOfAVariableTerm() {
-        assertEquals( "$hello", new Term.Variable("hello").toString() );
+        assertEquals("$hello", new Term.Variable("hello").toString());
     }
 
     @Test

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -101,7 +101,7 @@ public class BuilderTest {
     public void testArrayValueIsCopy() {
         byte[] someBytes = "Hello".getBytes(StandardCharsets.UTF_8);
         Term.Bytes term = new Term.Bytes(someBytes);
-        assertTrue(Arrays.equals(someBytes, term.getValue()), "same content");
+        assertArrayEquals(someBytes, term.getValue(), "content not the same");
         assertNotEquals(System.identityHashCode(someBytes), System.identityHashCode(term.getValue()), "different objects");
     }
 }

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -102,6 +102,6 @@ public class BuilderTest {
         byte[] someBytes = "Hello".getBytes(StandardCharsets.UTF_8);
         Term.Bytes term = new Term.Bytes(someBytes);
         assertArrayEquals(someBytes, term.getValue(), "content not the same");
-        assertNotEquals(System.identityHashCode(someBytes), System.identityHashCode(term.getValue()), "different objects");
+        assertNotEquals(System.identityHashCode(someBytes), System.identityHashCode(term.getValue()), "objects not different");
     }
 }

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -15,6 +15,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.*;
 
+import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BuilderTest {
@@ -58,7 +59,7 @@ public class BuilderTest {
         org.biscuitsec.biscuit.token.Block authority = authority_builder.build(symbols);
         Biscuit rootBiscuit = Biscuit.make(rng, root, authority);
 
-        System.out.println(rootBiscuit.print());
+        out.println(rootBiscuit.print());
 
         assertNotNull(rootBiscuit);
     }

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -13,10 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,12 +26,12 @@ public class BuilderTest {
         SymbolTable symbols = Biscuit.default_symbol_table();
 
         Block authority_builder = new Block();
-        authority_builder.add_fact(Utils.fact("revocation_id", Arrays.asList(Utils.date(Date.from(Instant.now())))));
-        authority_builder.add_fact(Utils.fact("right", Arrays.asList(Utils.s("admin"))));
+        authority_builder.add_fact(Utils.fact("revocation_id", List.of(Utils.date(Date.from(Instant.now())))));
+        authority_builder.add_fact(Utils.fact("right", List.of(Utils.s("admin"))));
         authority_builder.add_rule(Utils.constrained_rule("right",
                 Arrays.asList(Utils.s("namespace"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("operation")),
-                Arrays.asList(Utils.pred("ns_operation", Arrays.asList(Utils.s("namespace"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("operation")))),
-                Arrays.asList(
+                List.of(Utils.pred("ns_operation", Arrays.asList(Utils.s("namespace"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("operation")))),
+                List.of(
                         new Expression.Binary(
                                 Expression.Op.Contains,
                                 new Expression.Value(Utils.var("operation")),
@@ -47,12 +44,12 @@ public class BuilderTest {
         ));
         authority_builder.add_rule(Utils.constrained_rule("right",
                 Arrays.asList(Utils.s("topic"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("topic"), Utils.var("operation")),
-                Arrays.asList(Utils.pred("topic_operation", Arrays.asList(Utils.s("topic"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("topic"), Utils.var("operation")))),
-                Arrays.asList(
+                List.of(Utils.pred("topic_operation", Arrays.asList(Utils.s("topic"), Utils.var("tenant"), Utils.var("namespace"), Utils.var("topic"), Utils.var("operation")))),
+                List.of(
                         new Expression.Binary(
                                 Expression.Op.Contains,
                                 new Expression.Value(Utils.var("operation")),
-                                new Expression.Value(new Term.Set(new HashSet<>(Arrays.asList(
+                                new Expression.Value(new Term.Set(new HashSet<>(List.of(
                                         Utils.s("lookup")
                                 )))))
                 )

--- a/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
@@ -1,22 +1,23 @@
 package org.biscuitsec.biscuit.builder.parser;
 
 import biscuit.format.schema.Schema;
+import io.vavr.Tuple2;
+import io.vavr.control.Either;
 import org.biscuitsec.biscuit.crypto.PublicKey;
 import org.biscuitsec.biscuit.datalog.SymbolTable;
 import org.biscuitsec.biscuit.datalog.TemporarySymbolTable;
 import org.biscuitsec.biscuit.datalog.expressions.Op;
+import org.biscuitsec.biscuit.token.builder.*;
 import org.biscuitsec.biscuit.token.builder.parser.Error;
 import org.biscuitsec.biscuit.token.builder.parser.Parser;
-import io.vavr.Tuple2;
-import io.vavr.control.Either;
-import org.biscuitsec.biscuit.token.builder.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.biscuitsec.biscuit.datalog.Check.Kind.One;
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.*;
+
+import static org.biscuitsec.biscuit.datalog.Check.Kind.One;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ParserTest {
 
@@ -57,7 +58,7 @@ class ParserTest {
     void testFact() throws org.biscuitsec.biscuit.error.Error.Language {
         Either<Error, Tuple2<String, Fact>> res = Parser.fact("right( \"file1\", \"read\" )");
         assertEquals(Either.right(new Tuple2<>("",
-                Utils.fact("right", Arrays.asList(Utils.string("file1"), Utils.s("read"))))),
+                        Utils.fact("right", Arrays.asList(Utils.string("file1"), Utils.s("read"))))),
                 res);
 
         Either<Error, Tuple2<String, Fact>> res2 = Parser.fact("right( $var, \"read\" )");
@@ -91,7 +92,7 @@ class ParserTest {
 
     @Test
     void testRuleWithExpression() {
-            Either<Error, Tuple2<String, Rule>> res =
+        Either<Error, Tuple2<String, Rule>> res =
                 Parser.rule("valid_date(\"file1\") <- time($0 ), resource( \"file1\"), $0 <= 2019-12-04T09:46:41Z");
         assertEquals(Either.right(new Tuple2<>("",
                         Utils.constrained_rule("valid_date",
@@ -99,7 +100,7 @@ class ParserTest {
                                 Arrays.asList(
                                         Utils.pred("time", List.of(Utils.var("0"))),
                                         Utils.pred("resource", List.of(Utils.string("file1")))
-                                        ),
+                                ),
                                 List.of(
                                         new Expression.Binary(
                                                 Expression.Op.LessOrEqual,
@@ -157,12 +158,12 @@ class ParserTest {
                 new Expression.Binary(
                         Expression.Op.Equal,
                         new Expression.Unary(
-                            Expression.Op.Length,
-                            new Expression.Binary(
-                                    Expression.Op.Intersection,
-                                    new Expression.Value(Utils.set(new HashSet<>(Arrays.asList(Utils.integer(1), Utils.integer(2), Utils.integer(3))))),
-                                    new Expression.Value(Utils.set(new HashSet<>(Arrays.asList(Utils.integer(1), Utils.integer(2)))))
-                            )
+                                Expression.Op.Length,
+                                new Expression.Binary(
+                                        Expression.Op.Intersection,
+                                        new Expression.Value(Utils.set(new HashSet<>(Arrays.asList(Utils.integer(1), Utils.integer(2), Utils.integer(3))))),
+                                        new Expression.Value(Utils.set(new HashSet<>(Arrays.asList(Utils.integer(1), Utils.integer(2)))))
+                                )
                         ),
                         new Expression.Value(Utils.integer(2))
                 ))), res);
@@ -174,20 +175,20 @@ class ParserTest {
                 Parser.check("check if !false && true");
         assertEquals(Either.right(new Tuple2<>("",
                         Utils.check(
-                        Utils.constrained_rule("query",
-                                new ArrayList<>(),
-                                new ArrayList<>(),
-                                List.of(
-                                        new Expression.Binary(
-                                                Expression.Op.And,
-                                                new Expression.Unary(
-                                                        Expression.Op.Negate,
-                                                        new Expression.Value(new Term.Bool(false))
-                                                ),
-                                                new Expression.Value(new Term.Bool(true))
+                                Utils.constrained_rule("query",
+                                        new ArrayList<>(),
+                                        new ArrayList<>(),
+                                        List.of(
+                                                new Expression.Binary(
+                                                        Expression.Op.And,
+                                                        new Expression.Unary(
+                                                                Expression.Op.Negate,
+                                                                new Expression.Value(new Term.Bool(false))
+                                                        ),
+                                                        new Expression.Value(new Term.Bool(true))
+                                                )
                                         )
-                                )
-                        )))),
+                                )))),
                 res);
     }
 
@@ -230,22 +231,22 @@ class ParserTest {
         Either<Error, Tuple2<String, Check>> res =
                 Parser.check("check if resource($0), operation(\"read\") or admin()");
         assertEquals(Either.right(new Tuple2<>("", new Check(
-                One,
-                Arrays.asList(
-                    Utils.rule("query",
-                            new ArrayList<>(),
-                            Arrays.asList(
-                                    Utils.pred("resource", List.of(Utils.var("0"))),
-                                    Utils.pred("operation", List.of(Utils.s("read")))
-                            )
-                    ),
-                    Utils.rule("query",
-                            new ArrayList<>(),
-                            List.of(
-                                    Utils.pred("admin", List.of())
-                            )
-                    )
-                    )))),
+                        One,
+                        Arrays.asList(
+                                Utils.rule("query",
+                                        new ArrayList<>(),
+                                        Arrays.asList(
+                                                Utils.pred("resource", List.of(Utils.var("0"))),
+                                                Utils.pred("operation", List.of(Utils.s("read")))
+                                        )
+                                ),
+                                Utils.rule("query",
+                                        new ArrayList<>(),
+                                        List.of(
+                                                Utils.pred("admin", List.of())
+                                        )
+                                )
+                        )))),
                 res);
     }
 
@@ -255,7 +256,7 @@ class ParserTest {
                 Parser.expression(" -1 ");
 
         assertEquals(new Tuple2<String, Expression>("",
-                new Expression.Value(Utils.integer(-1))),
+                        new Expression.Value(Utils.integer(-1))),
                 res.get());
 
         Either<Error, Tuple2<String, Expression>> res2 =
@@ -464,7 +465,7 @@ class ParserTest {
         String l1 = "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)";
         String toParse = String.join(";", List.of(l1));
 
-        Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1,  toParse);
+        Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
         assertTrue(output.isRight());
 
         Block validBlock = new Block();
@@ -486,7 +487,7 @@ class ParserTest {
     }
 
     @Test
-    void testDatalogRemoveComment()  {
+    void testDatalogRemoveComment() {
         String l0 = "// test comment";
         String l1 = "fact1(1, 2);";
         String l2 = "fact2(\"2\");";

--- a/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
@@ -11,6 +11,7 @@ import java.security.SignatureException;
 
 import static io.vavr.API.Left;
 import static io.vavr.API.Right;
+import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -35,11 +36,11 @@ public class SignatureTest {
         assertEquals(32, serializedSecretKey.length);
         assertEquals(32, serializedPublicKey.length);
 
-        System.out.println(keypair.toHex());
-        System.out.println(deserializedSecretKey.toHex());
+        out.println(keypair.toHex());
+        out.println(deserializedSecretKey.toHex());
         assertEquals(keypair.toBytes(), deserializedSecretKey.toBytes());
-        System.out.println(pubkey.toHex());
-        System.out.println(deserializedPublicKey.toHex());
+        out.println(pubkey.toHex());
+        out.println(deserializedPublicKey.toHex());
         assertEquals(pubkey.toHex(), deserializedPublicKey.toHex());
     }
 
@@ -51,10 +52,10 @@ public class SignatureTest {
         String message1 = "hello";
         KeyPair root = new KeyPair(rng);
         KeyPair keypair2 = new KeyPair(rng);
-        System.out.println("root key: " + root.toHex());
-        System.out.println("keypair2: " + keypair2.toHex());
-        System.out.println("root key public: " + root.public_key().toHex());
-        System.out.println("keypair2 public: " + keypair2.public_key().toHex());
+        out.println("root key: " + root.toHex());
+        out.println("keypair2: " + keypair2.toHex());
+        out.println("root key public: " + root.public_key().toHex());
+        out.println("keypair2 public: " + keypair2.public_key().toHex());
 
         Token token1 = new Token(root, message1.getBytes(), keypair2);
         assertEquals(Right(null), token1.verify(root.public_key()));

--- a/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SignatureTest {
 
     @Test
-    public void testSerialize() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException {
+    public void testSerialize() {
         byte[] seed = {1, 2, 3, 4};
         SecureRandom rng = new SecureRandom(seed);
 

--- a/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/crypto/SignatureTest.java
@@ -1,6 +1,8 @@
 package org.biscuitsec.biscuit.crypto;
 
 import biscuit.format.schema.Schema;
+import org.biscuitsec.biscuit.error.Error;
+import org.junit.jupiter.api.Test;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -9,9 +11,6 @@ import java.security.SignatureException;
 
 import static io.vavr.API.Left;
 import static io.vavr.API.Right;
-
-import org.biscuitsec.biscuit.error.Error;
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/src/test/java/org/biscuitsec/biscuit/datalog/ExpressionTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/ExpressionTest.java
@@ -21,7 +21,7 @@ public class ExpressionTest {
         symbols.add("var");
 
 
-        Expression e = new Expression(new ArrayList<Op>(Arrays.asList(
+        Expression e = new Expression(new ArrayList<>(Arrays.asList(
                 new Op.Value(new Term.Integer(1)),
                 new Op.Value(new Term.Variable(SymbolTable.DEFAULT_SYMBOLS_OFFSET + 2)),
                 new Op.Binary(Op.BinaryOp.LessThan),
@@ -50,7 +50,7 @@ public class ExpressionTest {
         symbols.add("ab");
 
 
-        Expression e = new Expression(new ArrayList<Op>(Arrays.asList(
+        Expression e = new Expression(new ArrayList<>(Arrays.asList(
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET)),
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET + 1)),
                 new Op.Binary(Op.BinaryOp.Add)
@@ -74,7 +74,7 @@ public class ExpressionTest {
         symbols.add("b");
 
 
-        Expression e = new Expression(new ArrayList<Op>(Arrays.asList(
+        Expression e = new Expression(new ArrayList<>(Arrays.asList(
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET)),
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET + 1)),
                 new Op.Binary(Op.BinaryOp.Contains)
@@ -98,7 +98,7 @@ public class ExpressionTest {
         symbols.add("b");
 
 
-        Expression e = new Expression(new ArrayList<Op>(Arrays.asList(
+        Expression e = new Expression(new ArrayList<>(Arrays.asList(
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET)),
                 new Op.Value(new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET + 1)),
                 new Op.Binary(Op.BinaryOp.Contains),
@@ -120,7 +120,7 @@ public class ExpressionTest {
     public void testIntersectionAndContains() throws Error.Execution {
         SymbolTable symbols = new SymbolTable();
 
-        Expression e = new Expression(new ArrayList<Op>(Arrays.asList(
+        Expression e = new Expression(new ArrayList<>(Arrays.asList(
                 new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(1), new Term.Integer(2), new Term.Integer(3))))),
                 new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(1), new Term.Integer(2))))),
                 new Op.Binary(Op.BinaryOp.Intersection),

--- a/src/test/java/org/biscuitsec/biscuit/datalog/ExpressionTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/ExpressionTest.java
@@ -4,12 +4,13 @@ import org.biscuitsec.biscuit.datalog.expressions.Expression;
 import org.biscuitsec.biscuit.datalog.expressions.Op;
 import org.biscuitsec.biscuit.error.Error;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExpressionTest {
 
@@ -63,7 +64,7 @@ public class ExpressionTest {
 
         assertEquals(
                 new Term.Str(SymbolTable.DEFAULT_SYMBOLS_OFFSET + 2),
-                e.evaluate(new HashMap<>(),  new TemporarySymbolTable(symbols))
+                e.evaluate(new HashMap<>(), new TemporarySymbolTable(symbols))
         );
     }
 
@@ -87,7 +88,7 @@ public class ExpressionTest {
 
         assertEquals(
                 new Term.Bool(true),
-                e.evaluate(new HashMap<>(),  new TemporarySymbolTable(symbols))
+                e.evaluate(new HashMap<>(), new TemporarySymbolTable(symbols))
         );
     }
 
@@ -112,7 +113,7 @@ public class ExpressionTest {
 
         assertEquals(
                 new Term.Bool(false),
-                e.evaluate(new HashMap<>(),  new TemporarySymbolTable(symbols))
+                e.evaluate(new HashMap<>(), new TemporarySymbolTable(symbols))
         );
     }
 
@@ -135,7 +136,7 @@ public class ExpressionTest {
 
         assertEquals(
                 new Term.Bool(true),
-                e.evaluate(new HashMap<>(),  new TemporarySymbolTable(symbols))
+                e.evaluate(new HashMap<>(), new TemporarySymbolTable(symbols))
         );
     }
 }

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -284,10 +284,7 @@ public class WorldTest {
 
         System.out.println("testing r1: " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEach(fact -> System.out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
         assertEquals(expected, res);
 

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -38,8 +38,8 @@ public class WorldTest {
 
       System.out.println("testing r1: " + syms.print_rule(r1));
       FactSet query_rule_result = w.query_rule(r1, (long)0, new TrustedOrigins(0), syms);
-      System.out.println("grandparents query_rules: [" + String.join(", ", query_rule_result.stream().map((f) -> syms.print_fact(f)).collect(Collectors.toList())) + "]");
-      System.out.println("current facts: [" + String.join(", ", w.facts().stream().map((f) -> syms.print_fact(f)).collect(Collectors.toList())) + "]");
+      System.out.println("grandparents query_rules: [" + String.join(", ", query_rule_result.stream().map(syms::print_fact).collect(Collectors.toList())) + "]");
+      System.out.println("current facts: [" + String.join(", ", w.facts().stream().map(syms::print_fact).collect(Collectors.toList())) + "]");
 
       final Rule r2 = new Rule(new Predicate(grandparent,
               Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
@@ -67,7 +67,7 @@ public class WorldTest {
               new ArrayList<>());
       System.out.println("parents of B: [" + String.join(", ",
               w.query_rule(query2, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map((f) -> syms.print_fact(f)).collect(Collectors.toSet())) + "]");
+                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
       final Rule query3 = new Rule(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
               new Term.Variable(syms.insert("grandchild")))),
               List.of(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
@@ -75,7 +75,7 @@ public class WorldTest {
               new ArrayList<>());
       System.out.println("grandparents: [" + String.join(", ",
               w.query_rule(query3, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map((f) -> syms.print_fact(f)).collect(Collectors.toSet())) + "]");
+                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
       w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(c, e))));
       w.run(syms);
@@ -87,7 +87,7 @@ public class WorldTest {
               new ArrayList<>());
       final FactSet res = w.query_rule(query4, (long) 0, new TrustedOrigins(0), syms);
       System.out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
-              res.stream().map((f) -> syms.print_fact(f)).collect(Collectors.toSet())) + "]");
+              res.stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
       final FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(
               new Fact(new Predicate(grandparent, Arrays.asList(a, c))),
@@ -111,7 +111,7 @@ public class WorldTest {
               new ArrayList<>());
       System.out.println("siblings: [" + String.join(", ",
               w.query_rule(query5, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map((f) -> syms.print_fact(f)).collect(Collectors.toSet())) + "]");
+                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
    }
 
    @Test

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -54,7 +54,7 @@ public class WorldTest {
       System.out.println("parents:");
       final Rule query1 = new Rule(new Predicate(parent,
               Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child")))),
-              Arrays.asList(new Predicate(parent,
+              List.of(new Predicate(parent,
                       Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child"))))),
               new ArrayList<>());
 
@@ -63,14 +63,14 @@ public class WorldTest {
          System.out.println("\t" + syms.print_fact(fact));
       }
       final Rule query2 = new Rule(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b)),
-              Arrays.asList(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b))),
+              List.of(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b))),
               new ArrayList<>());
       System.out.println("parents of B: [" + String.join(", ",
               w.query_rule(query2, (long) 0, new TrustedOrigins(0), syms)
                       .stream().map((f) -> syms.print_fact(f)).collect(Collectors.toSet())) + "]");
       final Rule query3 = new Rule(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
               new Term.Variable(syms.insert("grandchild")))),
-              Arrays.asList(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
+              List.of(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
                       new Term.Variable(syms.insert("grandchild"))))),
               new ArrayList<>());
       System.out.println("grandparents: [" + String.join(", ",
@@ -82,8 +82,8 @@ public class WorldTest {
 
       final Rule query4 = new Rule(new Predicate(grandparent,
               Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))),
-              Arrays.asList(new Predicate(grandparent,
-                              Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild"))))),
+              List.of(new Predicate(grandparent,
+                      Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild"))))),
               new ArrayList<>());
       final FactSet res = w.query_rule(query4, (long) 0, new TrustedOrigins(0), syms);
       System.out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
@@ -105,7 +105,7 @@ public class WorldTest {
       final Rule query5 = new Rule(new Predicate(sibling, Arrays.asList(
               new Term.Variable(syms.insert("sibling1")),
               new Term.Variable(syms.insert("sibling2")))),
-              Arrays.asList(new Predicate(sibling, Arrays.asList(
+              List.of(new Predicate(sibling, Arrays.asList(
                       new Term.Variable(syms.insert("sibling1")),
                       new Term.Variable(syms.insert("sibling2"))))),
               new ArrayList<>());
@@ -168,11 +168,11 @@ public class WorldTest {
                                       new Term.Variable(syms.insert("t2_id")),
                                       new Term.Variable(syms.insert("right")),
                                       new Term.Variable(syms.insert("id"))))),
-              Arrays.asList(new Expression(new ArrayList<Op>(Arrays.asList(
+              List.of(new Expression(new ArrayList<Op>(Arrays.asList(
                       new Op.Value(new Term.Variable(syms.insert("id"))),
                       new Op.Value(new Term.Integer(1)),
                       new Op.Binary(Op.BinaryOp.LessThan)
-                      ))))
+              ))))
       ), (long) 0, new TrustedOrigins(0), syms);
        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
            Fact f = it.next();
@@ -186,13 +186,13 @@ public class WorldTest {
    private final FactSet testSuffix(final World w, SymbolTable syms, final long suff, final long route, final String suffix) throws Error {
       return w.query_rule(new Rule(new Predicate(suff,
               Arrays.asList(new Term.Variable(syms.insert("app_id")), new Term.Variable(syms.insert("domain")))),
-              Arrays.asList(
-            new Predicate(route, Arrays.asList(
-                    new Term.Variable(syms.insert("route_id")),
-                    new Term.Variable(syms.insert("app_id")),
-                    new Term.Variable(syms.insert("domain"))))
-      ),
-              Arrays.asList(new Expression(new ArrayList<Op>(Arrays.asList(
+              List.of(
+                      new Predicate(route, Arrays.asList(
+                              new Term.Variable(syms.insert("route_id")),
+                              new Term.Variable(syms.insert("app_id")),
+                              new Term.Variable(syms.insert("domain"))))
+              ),
+              List.of(new Expression(new ArrayList<Op>(Arrays.asList(
                       new Op.Value(new Term.Variable(syms.insert("domain"))),
                       new Op.Value(syms.add(suffix)),
                       new Op.Binary(Op.BinaryOp.Suffix)
@@ -223,7 +223,7 @@ public class WorldTest {
            System.out.println("\t" + syms.print_fact(f));
        }
       FactSet expected = new FactSet(new Origin(0),
-              new HashSet<>(Arrays.asList(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
+              new HashSet<>(List.of(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
       assertEquals(expected, res);
 
       res = testSuffix(w, syms, suff, route, "example.com");
@@ -267,7 +267,7 @@ public class WorldTest {
       final Rule r1 = new Rule(new Predicate(
               before,
               Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
-              Arrays.asList(
+              List.of(
                       new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
               ),
               Arrays.asList(
@@ -290,13 +290,13 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      FactSet expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
+      FactSet expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
       assertEquals(expected, res);
 
       final Rule r2 = new Rule(new Predicate(
               after,
               Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
-              Arrays.asList(
+              List.of(
                       new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
               ),
               Arrays.asList(
@@ -319,7 +319,7 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
+      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
       assertEquals(expected, res);
    }
 
@@ -342,10 +342,10 @@ public class WorldTest {
               int_set,
               Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("str")))
       ),
-              Arrays.asList(new Predicate(x,
+              List.of(new Predicate(x,
                       Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
-      ),
-              Arrays.asList(
+              ),
+              List.of(
                       new Expression(new ArrayList<Op>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0L), new Term.Integer(1L))))),
                               new Op.Value(new Term.Variable(syms.insert("int"))),
@@ -359,7 +359,7 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
+      FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
       assertEquals(expected, res);
 
       final long abc_sym_id = syms.insert("abc");
@@ -367,9 +367,9 @@ public class WorldTest {
 
       final Rule r2 = new Rule(new Predicate(symbol_set,
               Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
-              Arrays.asList(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
+              List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
               ),
-              Arrays.asList(
+              List.of(
                       new Expression(new ArrayList<Op>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Str(abc_sym_id), new Term.Str(ghi_sym_id))))),
                               new Op.Value(new Term.Variable(syms.insert("sym"))),
@@ -385,13 +385,13 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
+      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
       assertEquals(expected, res);
 
       final Rule r3 = new Rule(
               new Predicate(string_set, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
-              Arrays.asList(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))),
-              Arrays.asList(
+              List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))),
+              List.of(
                       new Expression(new ArrayList<Op>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(syms.add("test"), syms.add("aaa"))))),
                               new Op.Value(new Term.Variable(syms.insert("str"))),
@@ -405,7 +405,7 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
+      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
       assertEquals(expected, res);
    }
 
@@ -432,9 +432,9 @@ public class WorldTest {
       final long caveat1 = syms.insert("caveat1");
       //r1: caveat2(#file1) <- resource(#ambient, #file1)
       final Rule r1 = new Rule(
-              new Predicate(caveat1, Arrays.asList(file1)),
-              Arrays.asList(new Predicate(resource, Arrays.asList(file1))
-      ), new ArrayList<>());
+              new Predicate(caveat1, List.of(file1)),
+              List.of(new Predicate(resource, List.of(file1))
+              ), new ArrayList<>());
 
       System.out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
       FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
@@ -450,10 +450,10 @@ public class WorldTest {
       final Term var0 = new Term.Variable(var0_id);
       //r2: caveat1(0?) <- resource(#ambient, 0?) && operation(#ambient, #read) && right(#authority, 0?, #read)
       final Rule r2 = new Rule(
-              new Predicate(caveat2, Arrays.asList(var0)),
+              new Predicate(caveat2, List.of(var0)),
               Arrays.asList(
-                      new Predicate(resource, Arrays.asList(var0)),
-                      new Predicate(operation, Arrays.asList(read)),
+                      new Predicate(resource, List.of(var0)),
+                      new Predicate(operation, List.of(read)),
                       new Predicate(right, Arrays.asList(var0, read))
               ), new ArrayList<>());
 

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -38,8 +38,8 @@ public class WorldTest {
 
       System.out.println("testing r1: " + syms.print_rule(r1));
       FactSet query_rule_result = w.query_rule(r1, (long)0, new TrustedOrigins(0), syms);
-      System.out.println("grandparents query_rules: [" + String.join(", ", query_rule_result.stream().map(syms::print_fact).collect(Collectors.toList())) + "]");
-      System.out.println("current facts: [" + String.join(", ", w.facts().stream().map(syms::print_fact).collect(Collectors.toList())) + "]");
+      System.out.println("grandparents query_rules: [" + query_rule_result.stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
+      System.out.println("current facts: [" + w.facts().stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
 
       final Rule r2 = new Rule(new Predicate(grandparent,
               Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -183,7 +183,7 @@ public class WorldTest {
       assertEquals(expected, res);
    }
 
-   private final FactSet testSuffix(final World w, SymbolTable syms, final long suff, final long route, final String suffix) throws Error {
+   private FactSet testSuffix(final World w, SymbolTable syms, final long suff, final long route, final String suffix) throws Error {
       return w.query_rule(new Rule(new Predicate(suff,
               Arrays.asList(new Term.Variable(syms.insert("app_id")), new Term.Variable(syms.insert("domain")))),
               List.of(

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -4,463 +4,464 @@ import org.biscuitsec.biscuit.datalog.expressions.Expression;
 import org.biscuitsec.biscuit.datalog.expressions.Op;
 import org.biscuitsec.biscuit.error.Error;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class WorldTest {
 
-   @Test
-   public void testFamily() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
-      final Term a = syms.add("A");
-      final Term b = syms.add("B");
-      final Term c = syms.add("C");
-      final Term d = syms.add("D");
-      final Term e = syms.add("E");
-      final long parent = syms.insert("parent");
-      final long grandparent = syms.insert("grandparent");
-      final long sibling = syms.insert("siblings");
+    @Test
+    public void testFamily() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
+        final Term a = syms.add("A");
+        final Term b = syms.add("B");
+        final Term c = syms.add("C");
+        final Term d = syms.add("D");
+        final Term e = syms.add("E");
+        final long parent = syms.insert("parent");
+        final long grandparent = syms.insert("grandparent");
+        final long sibling = syms.insert("siblings");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(a, b))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(b, c))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(c, d))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(a, b))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(b, c))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(c, d))));
 
-      final Rule r1 = new Rule(new Predicate(grandparent,
-              Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("parent")))),
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
-      ), new ArrayList<>());
+        final Rule r1 = new Rule(new Predicate(grandparent,
+                Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("parent")))),
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
+        ), new ArrayList<>());
 
-      System.out.println("testing r1: " + syms.print_rule(r1));
-      FactSet query_rule_result = w.query_rule(r1, (long)0, new TrustedOrigins(0), syms);
-      System.out.println("grandparents query_rules: [" + query_rule_result.stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
-      System.out.println("current facts: [" + w.facts().stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
+        System.out.println("testing r1: " + syms.print_rule(r1));
+        FactSet query_rule_result = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
+        System.out.println("grandparents query_rules: [" + query_rule_result.stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
+        System.out.println("current facts: [" + w.facts().stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
 
-      final Rule r2 = new Rule(new Predicate(grandparent,
-              Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("parent")))),
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
-      ), new ArrayList<>());
+        final Rule r2 = new Rule(new Predicate(grandparent,
+                Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("parent")))),
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
+        ), new ArrayList<>());
 
-      System.out.println("adding r2: " + syms.print_rule(r2));
-      w.add_rule((long)0, new TrustedOrigins(0), r2);
-      w.run(syms);
+        System.out.println("adding r2: " + syms.print_rule(r2));
+        w.add_rule((long) 0, new TrustedOrigins(0), r2);
+        w.run(syms);
 
-      System.out.println("parents:");
-      final Rule query1 = new Rule(new Predicate(parent,
-              Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child")))),
-              List.of(new Predicate(parent,
-                      Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child"))))),
-              new ArrayList<>());
+        System.out.println("parents:");
+        final Rule query1 = new Rule(new Predicate(parent,
+                Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child")))),
+                List.of(new Predicate(parent,
+                        Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child"))))),
+                new ArrayList<>());
 
-      for (Iterator<Fact> it = w.query_rule(query1, (long) 0, new TrustedOrigins(0), syms).stream().iterator(); it.hasNext(); ) {
-         Fact fact = it.next();
-         System.out.println("\t" + syms.print_fact(fact));
-      }
-      final Rule query2 = new Rule(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b)),
-              List.of(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b))),
-              new ArrayList<>());
-      System.out.println("parents of B: [" + String.join(", ",
-              w.query_rule(query2, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
-      final Rule query3 = new Rule(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
-              new Term.Variable(syms.insert("grandchild")))),
-              List.of(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
-                      new Term.Variable(syms.insert("grandchild"))))),
-              new ArrayList<>());
-      System.out.println("grandparents: [" + String.join(", ",
-              w.query_rule(query3, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
+        for (Iterator<Fact> it = w.query_rule(query1, (long) 0, new TrustedOrigins(0), syms).stream().iterator(); it.hasNext(); ) {
+            Fact fact = it.next();
+            System.out.println("\t" + syms.print_fact(fact));
+        }
+        final Rule query2 = new Rule(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b)),
+                List.of(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b))),
+                new ArrayList<>());
+        System.out.println("parents of B: [" + String.join(", ",
+                w.query_rule(query2, (long) 0, new TrustedOrigins(0), syms)
+                        .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
+        final Rule query3 = new Rule(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
+                new Term.Variable(syms.insert("grandchild")))),
+                List.of(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
+                        new Term.Variable(syms.insert("grandchild"))))),
+                new ArrayList<>());
+        System.out.println("grandparents: [" + String.join(", ",
+                w.query_rule(query3, (long) 0, new TrustedOrigins(0), syms)
+                        .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(c, e))));
-      w.run(syms);
+        w.add_fact(new Origin(0), new Fact(new Predicate(parent, Arrays.asList(c, e))));
+        w.run(syms);
 
-      final Rule query4 = new Rule(new Predicate(grandparent,
-              Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))),
-              List.of(new Predicate(grandparent,
-                      Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild"))))),
-              new ArrayList<>());
-      final FactSet res = w.query_rule(query4, (long) 0, new TrustedOrigins(0), syms);
-      System.out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
-              res.stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
+        final Rule query4 = new Rule(new Predicate(grandparent,
+                Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))),
+                List.of(new Predicate(grandparent,
+                        Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild"))))),
+                new ArrayList<>());
+        final FactSet res = w.query_rule(query4, (long) 0, new TrustedOrigins(0), syms);
+        System.out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
+                res.stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
-      final FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(
-              new Fact(new Predicate(grandparent, Arrays.asList(a, c))),
-              new Fact(new Predicate(grandparent, Arrays.asList(b, d))),
-              new Fact(new Predicate(grandparent, Arrays.asList(b, e))))));
-      assertEquals(expected, res);
+        final FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(
+                new Fact(new Predicate(grandparent, Arrays.asList(a, c))),
+                new Fact(new Predicate(grandparent, Arrays.asList(b, d))),
+                new Fact(new Predicate(grandparent, Arrays.asList(b, e))))));
+        assertEquals(expected, res);
 
-      w.add_rule((long) 0, new TrustedOrigins(0), new Rule(new Predicate(sibling,
-              Arrays.asList(new Term.Variable(syms.insert("sibling1")), new Term.Variable(syms.insert("sibling2")))), Arrays.asList(
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("sibling1")))),
-            new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("sibling2"))))
-      ), new ArrayList<>()));
-      w.run(syms);
+        w.add_rule((long) 0, new TrustedOrigins(0), new Rule(new Predicate(sibling,
+                Arrays.asList(new Term.Variable(syms.insert("sibling1")), new Term.Variable(syms.insert("sibling2")))), Arrays.asList(
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("sibling1")))),
+                new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("sibling2"))))
+        ), new ArrayList<>()));
+        w.run(syms);
 
-      final Rule query5 = new Rule(new Predicate(sibling, Arrays.asList(
-              new Term.Variable(syms.insert("sibling1")),
-              new Term.Variable(syms.insert("sibling2")))),
-              List.of(new Predicate(sibling, Arrays.asList(
-                      new Term.Variable(syms.insert("sibling1")),
-                      new Term.Variable(syms.insert("sibling2"))))),
-              new ArrayList<>());
-      System.out.println("siblings: [" + String.join(", ",
-              w.query_rule(query5, (long) 0, new TrustedOrigins(0), syms)
-                      .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
-   }
+        final Rule query5 = new Rule(new Predicate(sibling, Arrays.asList(
+                new Term.Variable(syms.insert("sibling1")),
+                new Term.Variable(syms.insert("sibling2")))),
+                List.of(new Predicate(sibling, Arrays.asList(
+                        new Term.Variable(syms.insert("sibling1")),
+                        new Term.Variable(syms.insert("sibling2"))))),
+                new ArrayList<>());
+        System.out.println("siblings: [" + String.join(", ",
+                w.query_rule(query5, (long) 0, new TrustedOrigins(0), syms)
+                        .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
+    }
 
-   @Test
-   public void testNumbers() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
+    @Test
+    public void testNumbers() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
 
-      final Term abc = syms.add("abc");
-      final Term def = syms.add("def");
-      final Term ghi = syms.add("ghi");
-      final Term jkl = syms.add("jkl");
-      final Term mno = syms.add("mno");
-      final Term aaa = syms.add("AAA");
-      final Term bbb = syms.add("BBB");
-      final Term ccc = syms.add("CCC");
-      final long t1 = syms.insert("t1");
-      final long t2 = syms.insert("t2");
-      final long join = syms.insert("join");
+        final Term abc = syms.add("abc");
+        final Term def = syms.add("def");
+        final Term ghi = syms.add("ghi");
+        final Term jkl = syms.add("jkl");
+        final Term mno = syms.add("mno");
+        final Term aaa = syms.add("AAA");
+        final Term bbb = syms.add("BBB");
+        final Term ccc = syms.add("CCC");
+        final long t1 = syms.insert("t1");
+        final long t2 = syms.insert("t2");
+        final long join = syms.insert("join");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(0), abc))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(1), def))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(2), ghi))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(3), jkl))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(4), mno))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(0), abc))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(1), def))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(2), ghi))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(3), jkl))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t1, Arrays.asList(new Term.Integer(4), mno))));
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(0), aaa, new Term.Integer(0)))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(1), bbb, new Term.Integer(0)))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(2), ccc, new Term.Integer(1)))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(0), aaa, new Term.Integer(0)))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(1), bbb, new Term.Integer(0)))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(t2, Arrays.asList(new Term.Integer(2), ccc, new Term.Integer(1)))));
 
-      FactSet res = w.query_rule(new Rule(new Predicate(join,
-              Arrays.asList(new Term.Variable(syms.insert("left")), new Term.Variable(syms.insert("right")))
-            ),
-            Arrays.asList(new Predicate(t1, Arrays.asList(new Term.Variable(syms.insert("id")), new Term.Variable(syms.insert("left")))),
-                    new Predicate(t2,
-                            Arrays.asList(
-                                    new Term.Variable(syms.insert("t2_id")),
-                                    new Term.Variable(syms.insert("right")),
-                                    new Term.Variable(syms.insert("id"))))), new ArrayList<>()),
-              (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      FactSet expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))),
-              new Fact(new Predicate(join, Arrays.asList(abc, bbb))),
-              new Fact(new Predicate(join, Arrays.asList(def, ccc))))));
-      assertEquals(expected, res);
+        FactSet res = w.query_rule(new Rule(new Predicate(join,
+                        Arrays.asList(new Term.Variable(syms.insert("left")), new Term.Variable(syms.insert("right")))
+                ),
+                        Arrays.asList(new Predicate(t1, Arrays.asList(new Term.Variable(syms.insert("id")), new Term.Variable(syms.insert("left")))),
+                                new Predicate(t2,
+                                        Arrays.asList(
+                                                new Term.Variable(syms.insert("t2_id")),
+                                                new Term.Variable(syms.insert("right")),
+                                                new Term.Variable(syms.insert("id"))))), new ArrayList<>()),
+                (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))),
+                new Fact(new Predicate(join, Arrays.asList(abc, bbb))),
+                new Fact(new Predicate(join, Arrays.asList(def, ccc))))));
+        assertEquals(expected, res);
 
-      res = w.query_rule(new Rule(new Predicate(join,
-              Arrays.asList(new Term.Variable(syms.insert("left")), new Term.Variable(syms.insert("right")))),
-              Arrays.asList(new Predicate(t1, Arrays.asList(new Term.Variable(syms.insert("id")), new Term.Variable(syms.insert("left")))),
-                      new Predicate(t2,
-                              Arrays.asList(
-                                      new Term.Variable(syms.insert("t2_id")),
-                                      new Term.Variable(syms.insert("right")),
-                                      new Term.Variable(syms.insert("id"))))),
-              List.of(new Expression(new ArrayList<>(Arrays.asList(
-                      new Op.Value(new Term.Variable(syms.insert("id"))),
-                      new Op.Value(new Term.Integer(1)),
-                      new Op.Binary(Op.BinaryOp.LessThan)
-              ))))
-      ), (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      expected = new FactSet(new Origin(0),
-              new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))), new Fact(new Predicate(join, Arrays.asList(abc, bbb))))));
-      assertEquals(expected, res);
-   }
+        res = w.query_rule(new Rule(new Predicate(join,
+                Arrays.asList(new Term.Variable(syms.insert("left")), new Term.Variable(syms.insert("right")))),
+                Arrays.asList(new Predicate(t1, Arrays.asList(new Term.Variable(syms.insert("id")), new Term.Variable(syms.insert("left")))),
+                        new Predicate(t2,
+                                Arrays.asList(
+                                        new Term.Variable(syms.insert("t2_id")),
+                                        new Term.Variable(syms.insert("right")),
+                                        new Term.Variable(syms.insert("id"))))),
+                List.of(new Expression(new ArrayList<>(Arrays.asList(
+                        new Op.Value(new Term.Variable(syms.insert("id"))),
+                        new Op.Value(new Term.Integer(1)),
+                        new Op.Binary(Op.BinaryOp.LessThan)
+                ))))
+        ), (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        expected = new FactSet(new Origin(0),
+                new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))), new Fact(new Predicate(join, Arrays.asList(abc, bbb))))));
+        assertEquals(expected, res);
+    }
 
-   private FactSet testSuffix(final World w, SymbolTable syms, final long suff, final long route, final String suffix) throws Error {
-      return w.query_rule(new Rule(new Predicate(suff,
-              Arrays.asList(new Term.Variable(syms.insert("app_id")), new Term.Variable(syms.insert("domain")))),
-              List.of(
-                      new Predicate(route, Arrays.asList(
-                              new Term.Variable(syms.insert("route_id")),
-                              new Term.Variable(syms.insert("app_id")),
-                              new Term.Variable(syms.insert("domain"))))
-              ),
-              List.of(new Expression(new ArrayList<>(Arrays.asList(
-                      new Op.Value(new Term.Variable(syms.insert("domain"))),
-                      new Op.Value(syms.add(suffix)),
-                      new Op.Binary(Op.BinaryOp.Suffix)
-              ))))
-      ), (long) 0, new TrustedOrigins(0), syms);
-   }
+    private FactSet testSuffix(final World w, SymbolTable syms, final long suff, final long route, final String suffix) throws Error {
+        return w.query_rule(new Rule(new Predicate(suff,
+                Arrays.asList(new Term.Variable(syms.insert("app_id")), new Term.Variable(syms.insert("domain")))),
+                List.of(
+                        new Predicate(route, Arrays.asList(
+                                new Term.Variable(syms.insert("route_id")),
+                                new Term.Variable(syms.insert("app_id")),
+                                new Term.Variable(syms.insert("domain"))))
+                ),
+                List.of(new Expression(new ArrayList<>(Arrays.asList(
+                        new Op.Value(new Term.Variable(syms.insert("domain"))),
+                        new Op.Value(syms.add(suffix)),
+                        new Op.Binary(Op.BinaryOp.Suffix)
+                ))))
+        ), (long) 0, new TrustedOrigins(0), syms);
+    }
 
-   @Test
-   public void testStr() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
+    @Test
+    public void testStr() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
 
-      final Term app_0 = syms.add("app_0");
-      final Term app_1 = syms.add("app_1");
-      final Term app_2 = syms.add("app_2");
-      final long route = syms.insert("route");
-      final long suff = syms.insert("route suffix");
+        final Term app_0 = syms.add("app_0");
+        final Term app_1 = syms.add("app_1");
+        final Term app_2 = syms.add("app_2");
+        final long route = syms.insert("route");
+        final long suff = syms.insert("route suffix");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(0), app_0, syms.add("example.com")))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(1), app_1, syms.add("test.com")))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(2), app_2, syms.add("test.fr")))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(3), app_0, syms.add("www.example.com")))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(4), app_1, syms.add("mx.example.com")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(0), app_0, syms.add("example.com")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(1), app_1, syms.add("test.com")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(2), app_2, syms.add("test.fr")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(3), app_0, syms.add("www.example.com")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(4), app_1, syms.add("mx.example.com")))));
 
-      FactSet res = testSuffix(w, syms, suff, route, ".fr");
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      FactSet expected = new FactSet(new Origin(0),
-              new HashSet<>(List.of(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
-      assertEquals(expected, res);
+        FactSet res = testSuffix(w, syms, suff, route, ".fr");
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        FactSet expected = new FactSet(new Origin(0),
+                new HashSet<>(List.of(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
+        assertEquals(expected, res);
 
-      res = testSuffix(w, syms, suff, route, "example.com");
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      expected = new FactSet(new Origin(0),new HashSet<>(Arrays.asList(new Fact(new Predicate(suff,
-              Arrays.asList(
-                      app_0,
-                      syms.add("example.com")))),
-              new Fact(new Predicate(suff,
-                      Arrays.asList(app_0, syms.add("www.example.com")))),
-              new Fact(new Predicate(suff, Arrays.asList(app_1, syms.add("mx.example.com")))))));
-      assertEquals(expected, res);
-   }
+        res = testSuffix(w, syms, suff, route, "example.com");
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(suff,
+                        Arrays.asList(
+                                app_0,
+                                syms.add("example.com")))),
+                new Fact(new Predicate(suff,
+                        Arrays.asList(app_0, syms.add("www.example.com")))),
+                new Fact(new Predicate(suff, Arrays.asList(app_1, syms.add("mx.example.com")))))));
+        assertEquals(expected, res);
+    }
 
-   @Test
-   public void testDate() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
+    @Test
+    public void testDate() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
 
-      final Instant t1 = Instant.now();
-      System.out.println("t1 = " + t1);
-      final Instant t2 = t1.plusSeconds(10);
-      System.out.println("t2 = " + t2);
-      final Instant t3 = t2.plusSeconds(30);
-      System.out.println("t3 = " + t3);
+        final Instant t1 = Instant.now();
+        System.out.println("t1 = " + t1);
+        final Instant t2 = t1.plusSeconds(10);
+        System.out.println("t2 = " + t2);
+        final Instant t3 = t2.plusSeconds(30);
+        System.out.println("t3 = " + t3);
 
-      final long t2_timestamp = t2.getEpochSecond();
+        final long t2_timestamp = t2.getEpochSecond();
 
-      final Term abc = syms.add("abc");
-      final Term def = syms.add("def");
-      final long x = syms.insert("x");
-      final long before = syms.insert("before");
-      final long after = syms.insert("after");
+        final Term abc = syms.add("abc");
+        final Term def = syms.add("def");
+        final long x = syms.insert("x");
+        final long before = syms.insert("before");
+        final long after = syms.insert("after");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))));
 
-      final Rule r1 = new Rule(new Predicate(
-              before,
-              Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
-              List.of(
-                      new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
-              ),
-              Arrays.asList(
-                   new Expression(new ArrayList<>(Arrays.asList(
-                           new Op.Value(new Term.Variable(syms.insert("date"))),
-                           new Op.Value(new Term.Date(t2_timestamp)),
-                           new Op.Binary(Op.BinaryOp.LessOrEqual)
-                   ))),
-                   new Expression(new ArrayList<>(Arrays.asList(
-                           new Op.Value(new Term.Variable(syms.insert("date"))),
-                           new Op.Value(new Term.Date(0)),
-                           new Op.Binary(Op.BinaryOp.GreaterOrEqual)
-                   )))
-              )
-      );
+        final Rule r1 = new Rule(new Predicate(
+                before,
+                Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
+                List.of(
+                        new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
+                ),
+                Arrays.asList(
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Variable(syms.insert("date"))),
+                                new Op.Value(new Term.Date(t2_timestamp)),
+                                new Op.Binary(Op.BinaryOp.LessOrEqual)
+                        ))),
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Variable(syms.insert("date"))),
+                                new Op.Value(new Term.Date(0)),
+                                new Op.Binary(Op.BinaryOp.GreaterOrEqual)
+                        )))
+                )
+        );
 
-      System.out.println("testing r1: " + syms.print_rule(r1));
-      FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      FactSet expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
-      assertEquals(expected, res);
+        System.out.println("testing r1: " + syms.print_rule(r1));
+        FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
+        assertEquals(expected, res);
 
-      final Rule r2 = new Rule(new Predicate(
-              after,
-              Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
-              List.of(
-                      new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
-              ),
-              Arrays.asList(
-                      new Expression(new ArrayList<>(Arrays.asList(
-                              new Op.Value(new Term.Variable(syms.insert("date"))),
-                              new Op.Value(new Term.Date(t2_timestamp)),
-                              new Op.Binary(Op.BinaryOp.GreaterOrEqual)
-                      ))),
-                     new Expression(new ArrayList<>(Arrays.asList(
-                             new Op.Value(new Term.Variable(syms.insert("date"))),
-                             new Op.Value(new Term.Date(0)),
-                             new Op.Binary(Op.BinaryOp.GreaterOrEqual)
-                     )))
-              )
-      );
+        final Rule r2 = new Rule(new Predicate(
+                after,
+                Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val")))),
+                List.of(
+                        new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
+                ),
+                Arrays.asList(
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Variable(syms.insert("date"))),
+                                new Op.Value(new Term.Date(t2_timestamp)),
+                                new Op.Binary(Op.BinaryOp.GreaterOrEqual)
+                        ))),
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Variable(syms.insert("date"))),
+                                new Op.Value(new Term.Date(0)),
+                                new Op.Binary(Op.BinaryOp.GreaterOrEqual)
+                        )))
+                )
+        );
 
-      System.out.println("testing r2: " + syms.print_rule(r2));
-      res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
-      assertEquals(expected, res);
-   }
+        System.out.println("testing r2: " + syms.print_rule(r2));
+        res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
+        assertEquals(expected, res);
+    }
 
-   @Test
-   public void testSet() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
+    @Test
+    public void testSet() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
 
-      final Term abc = syms.add("abc");
-      final Term def = syms.add("def");
-      final long x = syms.insert("x");
-      final long int_set = syms.insert("int_set");
-      final long symbol_set = syms.insert("symbol_set");
-      final long string_set = syms.insert("string_set");
+        final Term abc = syms.add("abc");
+        final Term def = syms.add("def");
+        final long x = syms.insert("x");
+        final long int_set = syms.insert("int_set");
+        final long symbol_set = syms.insert("symbol_set");
+        final long string_set = syms.insert("string_set");
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(x, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))));
 
-      final Rule r1 = new Rule(new Predicate(
-              int_set,
-              Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("str")))
-      ),
-              List.of(new Predicate(x,
-                      Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
-              ),
-              List.of(
-                      new Expression(new ArrayList<>(Arrays.asList(
-                              new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0L), new Term.Integer(1L))))),
-                              new Op.Value(new Term.Variable(syms.insert("int"))),
-                              new Op.Binary(Op.BinaryOp.Contains)
-                      )))
-              )
-      );
-      System.out.println("testing r1: " + syms.print_rule(r1));
-      FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
-      assertEquals(expected, res);
+        final Rule r1 = new Rule(new Predicate(
+                int_set,
+                Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("str")))
+        ),
+                List.of(new Predicate(x,
+                        Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
+                ),
+                List.of(
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0L), new Term.Integer(1L))))),
+                                new Op.Value(new Term.Variable(syms.insert("int"))),
+                                new Op.Binary(Op.BinaryOp.Contains)
+                        )))
+                )
+        );
+        System.out.println("testing r1: " + syms.print_rule(r1));
+        FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
+        assertEquals(expected, res);
 
-      final long abc_sym_id = syms.insert("abc");
-      final long ghi_sym_id = syms.insert("ghi");
+        final long abc_sym_id = syms.insert("abc");
+        final long ghi_sym_id = syms.insert("ghi");
 
-      final Rule r2 = new Rule(new Predicate(symbol_set,
-              Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
-              List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
-              ),
-              List.of(
-                      new Expression(new ArrayList<>(Arrays.asList(
-                              new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Str(abc_sym_id), new Term.Str(ghi_sym_id))))),
-                              new Op.Value(new Term.Variable(syms.insert("sym"))),
-                              new Op.Binary(Op.BinaryOp.Contains),
-                              new Op.Unary(Op.UnaryOp.Negate)
-                      )))
-              )
-      );
+        final Rule r2 = new Rule(new Predicate(symbol_set,
+                Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
+                List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
+                ),
+                List.of(
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Str(abc_sym_id), new Term.Str(ghi_sym_id))))),
+                                new Op.Value(new Term.Variable(syms.insert("sym"))),
+                                new Op.Binary(Op.BinaryOp.Contains),
+                                new Op.Unary(Op.UnaryOp.Negate)
+                        )))
+                )
+        );
 
-      System.out.println("testing r2: " + syms.print_rule(r2));
-      res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
-      assertEquals(expected, res);
+        System.out.println("testing r2: " + syms.print_rule(r2));
+        res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
+        assertEquals(expected, res);
 
-      final Rule r3 = new Rule(
-              new Predicate(string_set, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
-              List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))),
-              List.of(
-                      new Expression(new ArrayList<>(Arrays.asList(
-                              new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(syms.add("test"), syms.add("aaa"))))),
-                              new Op.Value(new Term.Variable(syms.insert("str"))),
-                              new Op.Binary(Op.BinaryOp.Contains)
-                      )))
-              )
-      );
-      System.out.println("testing r3: " + syms.print_rule(r3));
-      res = w.query_rule(r3, (long) 0, new TrustedOrigins(0), syms);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-      expected = new FactSet(new Origin(0),new HashSet<>(List.of(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
-      assertEquals(expected, res);
-   }
+        final Rule r3 = new Rule(
+                new Predicate(string_set, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
+                List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))),
+                List.of(
+                        new Expression(new ArrayList<>(Arrays.asList(
+                                new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(syms.add("test"), syms.add("aaa"))))),
+                                new Op.Value(new Term.Variable(syms.insert("str"))),
+                                new Op.Binary(Op.BinaryOp.Contains)
+                        )))
+                )
+        );
+        System.out.println("testing r3: " + syms.print_rule(r3));
+        res = w.query_rule(r3, (long) 0, new TrustedOrigins(0), syms);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
+        assertEquals(expected, res);
+    }
 
-   @Test
-   public void testResource() throws Error {
-      final World w = new World();
-      final SymbolTable syms = new SymbolTable();
+    @Test
+    public void testResource() throws Error {
+        final World w = new World();
+        final SymbolTable syms = new SymbolTable();
 
-      final long resource = syms.insert("resource");
-      final long operation = syms.insert("operation");
-      final long right = syms.insert("right");
-      final Term file1 = syms.add("file1");
-      final Term file2 = syms.add("file2");
-      final Term read = syms.add("read");
-      final Term write = syms.add("write");
+        final long resource = syms.insert("resource");
+        final long operation = syms.insert("operation");
+        final long right = syms.insert("right");
+        final Term file1 = syms.add("file1");
+        final Term file2 = syms.add("file2");
+        final Term read = syms.add("read");
+        final Term write = syms.add("write");
 
 
-      w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file1, read))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file2, read))));
-      w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file1, write))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file1, read))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file2, read))));
+        w.add_fact(new Origin(0), new Fact(new Predicate(right, Arrays.asList(file1, write))));
 
-      final long caveat1 = syms.insert("caveat1");
-      //r1: caveat2(#file1) <- resource(#ambient, #file1)
-      final Rule r1 = new Rule(
-              new Predicate(caveat1, List.of(file1)),
-              List.of(new Predicate(resource, List.of(file1))
-              ), new ArrayList<>());
+        final long caveat1 = syms.insert("caveat1");
+        //r1: caveat2(#file1) <- resource(#ambient, #file1)
+        final Rule r1 = new Rule(
+                new Predicate(caveat1, List.of(file1)),
+                List.of(new Predicate(resource, List.of(file1))
+                ), new ArrayList<>());
 
-      System.out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
-      FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-      System.out.println(res);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-       assertEquals(0, res.size());
+        System.out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
+        FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
+        System.out.println(res);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        assertEquals(0, res.size());
 
-      final long caveat2 = syms.insert("caveat2");
-      final long var0_id = syms.insert("var0");
-      final Term var0 = new Term.Variable(var0_id);
-      //r2: caveat1(0?) <- resource(#ambient, 0?) && operation(#ambient, #read) && right(#authority, 0?, #read)
-      final Rule r2 = new Rule(
-              new Predicate(caveat2, List.of(var0)),
-              Arrays.asList(
-                      new Predicate(resource, List.of(var0)),
-                      new Predicate(operation, List.of(read)),
-                      new Predicate(right, Arrays.asList(var0, read))
-              ), new ArrayList<>());
+        final long caveat2 = syms.insert("caveat2");
+        final long var0_id = syms.insert("var0");
+        final Term var0 = new Term.Variable(var0_id);
+        //r2: caveat1(0?) <- resource(#ambient, 0?) && operation(#ambient, #read) && right(#authority, 0?, #read)
+        final Rule r2 = new Rule(
+                new Predicate(caveat2, List.of(var0)),
+                Arrays.asList(
+                        new Predicate(resource, List.of(var0)),
+                        new Predicate(operation, List.of(read)),
+                        new Predicate(right, Arrays.asList(var0, read))
+                ), new ArrayList<>());
 
-      System.out.println("testing caveat 2: " + syms.print_rule(r2));
-      res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-      System.out.println(res);
-       for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-           Fact f = it.next();
-           System.out.println("\t" + syms.print_fact(f));
-       }
-       assertEquals(0, res.size());
-   }
+        System.out.println("testing caveat 2: " + syms.print_rule(r2));
+        res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
+        System.out.println(res);
+        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
+            Fact f = it.next();
+            System.out.println("\t" + syms.print_fact(f));
+        }
+        assertEquals(0, res.size());
+    }
 }

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -5,7 +5,6 @@ import org.biscuitsec.biscuit.datalog.expressions.Op;
 import org.biscuitsec.biscuit.error.Error;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.*;

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WorldTest {
@@ -36,10 +37,10 @@ public class WorldTest {
                 new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
         ), new ArrayList<>());
 
-        System.out.println("testing r1: " + syms.print_rule(r1));
+        out.println("testing r1: " + syms.print_rule(r1));
         FactSet query_rule_result = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        System.out.println("grandparents query_rules: [" + query_rule_result.stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
-        System.out.println("current facts: [" + w.facts().stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
+        out.println("grandparents query_rules: [" + query_rule_result.stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
+        out.println("current facts: [" + w.facts().stream().map(syms::print_fact).collect(Collectors.joining(", ")) + "]");
 
         final Rule r2 = new Rule(new Predicate(grandparent,
                 Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild")))), Arrays.asList(
@@ -47,11 +48,11 @@ public class WorldTest {
                 new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("grandchild"))))
         ), new ArrayList<>());
 
-        System.out.println("adding r2: " + syms.print_rule(r2));
+        out.println("adding r2: " + syms.print_rule(r2));
         w.add_rule((long) 0, new TrustedOrigins(0), r2);
         w.run(syms);
 
-        System.out.println("parents:");
+        out.println("parents:");
         final Rule query1 = new Rule(new Predicate(parent,
                 Arrays.asList(new Term.Variable(syms.insert("parent")), new Term.Variable(syms.insert("child")))),
                 List.of(new Predicate(parent,
@@ -60,12 +61,12 @@ public class WorldTest {
 
         for (Iterator<Fact> it = w.query_rule(query1, (long) 0, new TrustedOrigins(0), syms).stream().iterator(); it.hasNext(); ) {
             Fact fact = it.next();
-            System.out.println("\t" + syms.print_fact(fact));
+            out.println("\t" + syms.print_fact(fact));
         }
         final Rule query2 = new Rule(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b)),
                 List.of(new Predicate(parent, Arrays.asList(new Term.Variable(syms.insert("parent")), b))),
                 new ArrayList<>());
-        System.out.println("parents of B: [" + String.join(", ",
+        out.println("parents of B: [" + String.join(", ",
                 w.query_rule(query2, (long) 0, new TrustedOrigins(0), syms)
                         .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
         final Rule query3 = new Rule(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
@@ -73,7 +74,7 @@ public class WorldTest {
                 List.of(new Predicate(grandparent, Arrays.asList(new Term.Variable(syms.insert("grandparent")),
                         new Term.Variable(syms.insert("grandchild"))))),
                 new ArrayList<>());
-        System.out.println("grandparents: [" + String.join(", ",
+        out.println("grandparents: [" + String.join(", ",
                 w.query_rule(query3, (long) 0, new TrustedOrigins(0), syms)
                         .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
@@ -86,7 +87,7 @@ public class WorldTest {
                         Arrays.asList(new Term.Variable(syms.insert("grandparent")), new Term.Variable(syms.insert("grandchild"))))),
                 new ArrayList<>());
         final FactSet res = w.query_rule(query4, (long) 0, new TrustedOrigins(0), syms);
-        System.out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
+        out.println("grandparents after inserting parent(C, E): [" + String.join(", ",
                 res.stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
 
         final FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(
@@ -109,7 +110,7 @@ public class WorldTest {
                         new Term.Variable(syms.insert("sibling1")),
                         new Term.Variable(syms.insert("sibling2"))))),
                 new ArrayList<>());
-        System.out.println("siblings: [" + String.join(", ",
+        out.println("siblings: [" + String.join(", ",
                 w.query_rule(query5, (long) 0, new TrustedOrigins(0), syms)
                         .stream().map(syms::print_fact).collect(Collectors.toSet())) + "]");
     }
@@ -153,7 +154,7 @@ public class WorldTest {
                 (long) 0, new TrustedOrigins(0), syms);
         for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
             Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
+            out.println("\t" + syms.print_fact(f));
         }
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))),
                 new Fact(new Predicate(join, Arrays.asList(abc, bbb))),
@@ -176,7 +177,7 @@ public class WorldTest {
         ), (long) 0, new TrustedOrigins(0), syms);
         for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
             Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
+            out.println("\t" + syms.print_fact(f));
         }
         expected = new FactSet(new Origin(0),
                 new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))), new Fact(new Predicate(join, Arrays.asList(abc, bbb))))));
@@ -220,14 +221,14 @@ public class WorldTest {
         FactSet res = testSuffix(w, syms, suff, route, ".fr");
         for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
             Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
+            out.println("\t" + syms.print_fact(f));
         }
         FactSet expected = new FactSet(new Origin(0),
                 new HashSet<>(List.of(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
         assertEquals(expected, res);
 
         res = testSuffix(w, syms, suff, route, "example.com");
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
 
         expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(suff,
                         Arrays.asList(
@@ -245,11 +246,11 @@ public class WorldTest {
         final SymbolTable syms = new SymbolTable();
 
         final Instant t1 = Instant.now();
-        System.out.println("t1 = " + t1);
+        out.println("t1 = " + t1);
         final Instant t2 = t1.plusSeconds(10);
-        System.out.println("t2 = " + t2);
+        out.println("t2 = " + t2);
         final Instant t3 = t2.plusSeconds(30);
-        System.out.println("t3 = " + t3);
+        out.println("t3 = " + t3);
 
         final long t2_timestamp = t2.getEpochSecond();
 
@@ -282,9 +283,9 @@ public class WorldTest {
                 )
         );
 
-        System.out.println("testing r1: " + syms.print_rule(r1));
+        out.println("testing r1: " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
         assertEquals(expected, res);
 
@@ -308,9 +309,9 @@ public class WorldTest {
                 )
         );
 
-        System.out.println("testing r2: " + syms.print_rule(r2));
+        out.println("testing r2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
         assertEquals(expected, res);
     }
@@ -345,9 +346,9 @@ public class WorldTest {
                         )))
                 )
         );
-        System.out.println("testing r1: " + syms.print_rule(r1));
+        out.println("testing r1: " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
         assertEquals(expected, res);
 
@@ -368,9 +369,9 @@ public class WorldTest {
                 )
         );
 
-        System.out.println("testing r2: " + syms.print_rule(r2));
+        out.println("testing r2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
         assertEquals(expected, res);
 
@@ -385,9 +386,9 @@ public class WorldTest {
                         )))
                 )
         );
-        System.out.println("testing r3: " + syms.print_rule(r3));
+        out.println("testing r3: " + syms.print_rule(r3));
         res = w.query_rule(r3, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
         assertEquals(expected, res);
     }
@@ -417,10 +418,10 @@ public class WorldTest {
                 List.of(new Predicate(resource, List.of(file1))
                 ), new ArrayList<>());
 
-        System.out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
+        out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        System.out.println(res);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        out.println(res);
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         assertEquals(0, res.size());
 
         final long caveat2 = syms.insert("caveat2");
@@ -435,10 +436,10 @@ public class WorldTest {
                         new Predicate(right, Arrays.asList(var0, read))
                 ), new ArrayList<>());
 
-        System.out.println("testing caveat 2: " + syms.print_rule(r2));
+        out.println("testing caveat 2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-        System.out.println(res);
-        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        out.println(res);
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         assertEquals(0, res.size());
     }
 }

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -441,7 +441,7 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      assertTrue(res.size() == 0);
+       assertEquals(0, res.size());
 
       final long caveat2 = syms.insert("caveat2");
       final long var0_id = syms.insert("var0");
@@ -462,6 +462,6 @@ public class WorldTest {
            Fact f = it.next();
            System.out.println("\t" + syms.print_fact(f));
        }
-      assertTrue(res.size() == 0);
+       assertEquals(0, res.size());
    }
 }

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -175,10 +175,7 @@ public class WorldTest {
                         new Op.Binary(Op.BinaryOp.LessThan)
                 ))))
         ), (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0),
                 new HashSet<>(Arrays.asList(new Fact(new Predicate(join, Arrays.asList(abc, aaa))), new Fact(new Predicate(join, Arrays.asList(abc, bbb))))));
         assertEquals(expected, res);
@@ -219,10 +216,7 @@ public class WorldTest {
         w.add_fact(new Origin(0), new Fact(new Predicate(route, Arrays.asList(new Term.Integer(4), app_1, syms.add("mx.example.com")))));
 
         FactSet res = testSuffix(w, syms, suff, route, ".fr");
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0),
                 new HashSet<>(List.of(new Fact(new Predicate(suff, Arrays.asList(app_2, syms.add("test.fr")))))));
         assertEquals(expected, res);

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -227,7 +227,7 @@ public class WorldTest {
         assertEquals(expected, res);
 
         res = testSuffix(w, syms, suff, route, "example.com");
-        res.stream().forEach(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
 
         expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(suff,
                         Arrays.asList(
@@ -284,7 +284,7 @@ public class WorldTest {
 
         System.out.println("testing r1: " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        res.stream().forEach(fact -> System.out.println("\t" + syms.print_fact(fact)));
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(before, Arrays.asList(new Term.Date(t1.getEpochSecond()), abc))))));
         assertEquals(expected, res);
 
@@ -310,10 +310,7 @@ public class WorldTest {
 
         System.out.println("testing r2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(after, Arrays.asList(new Term.Date(t3.getEpochSecond()), def))))));
         assertEquals(expected, res);
     }
@@ -350,10 +347,7 @@ public class WorldTest {
         );
         System.out.println("testing r1: " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         FactSet expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(int_set, Arrays.asList(abc, syms.add("test")))))));
         assertEquals(expected, res);
 
@@ -376,10 +370,7 @@ public class WorldTest {
 
         System.out.println("testing r2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(symbol_set, Arrays.asList(def, new Term.Integer(2), syms.add("hello")))))));
         assertEquals(expected, res);
 
@@ -396,10 +387,7 @@ public class WorldTest {
         );
         System.out.println("testing r3: " + syms.print_rule(r3));
         res = w.query_rule(r3, (long) 0, new TrustedOrigins(0), syms);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         expected = new FactSet(new Origin(0), new HashSet<>(List.of(new Fact(new Predicate(string_set, Arrays.asList(abc, new Term.Integer(0), syms.add("test")))))));
         assertEquals(expected, res);
     }
@@ -432,10 +420,7 @@ public class WorldTest {
         System.out.println("testing caveat 1(should return nothing): " + syms.print_rule(r1));
         FactSet res = w.query_rule(r1, (long) 0, new TrustedOrigins(0), syms);
         System.out.println(res);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         assertEquals(0, res.size());
 
         final long caveat2 = syms.insert("caveat2");
@@ -453,10 +438,7 @@ public class WorldTest {
         System.out.println("testing caveat 2: " + syms.print_rule(r2));
         res = w.query_rule(r2, (long) 0, new TrustedOrigins(0), syms);
         System.out.println(res);
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEachOrdered(fact -> System.out.println("\t" + syms.print_fact(fact)));
         assertEquals(0, res.size());
     }
 }

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -347,7 +347,7 @@ public class WorldTest {
       ),
               Arrays.asList(
                       new Expression(new ArrayList<Op>(Arrays.asList(
-                              new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0l), new Term.Integer(1l))))),
+                              new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0L), new Term.Integer(1L))))),
                               new Op.Value(new Term.Variable(syms.insert("int"))),
                               new Op.Binary(Op.BinaryOp.Contains)
                       )))

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -168,7 +168,7 @@ public class WorldTest {
                                       new Term.Variable(syms.insert("t2_id")),
                                       new Term.Variable(syms.insert("right")),
                                       new Term.Variable(syms.insert("id"))))),
-              List.of(new Expression(new ArrayList<Op>(Arrays.asList(
+              List.of(new Expression(new ArrayList<>(Arrays.asList(
                       new Op.Value(new Term.Variable(syms.insert("id"))),
                       new Op.Value(new Term.Integer(1)),
                       new Op.Binary(Op.BinaryOp.LessThan)
@@ -192,7 +192,7 @@ public class WorldTest {
                               new Term.Variable(syms.insert("app_id")),
                               new Term.Variable(syms.insert("domain"))))
               ),
-              List.of(new Expression(new ArrayList<Op>(Arrays.asList(
+              List.of(new Expression(new ArrayList<>(Arrays.asList(
                       new Op.Value(new Term.Variable(syms.insert("domain"))),
                       new Op.Value(syms.add(suffix)),
                       new Op.Binary(Op.BinaryOp.Suffix)
@@ -271,12 +271,12 @@ public class WorldTest {
                       new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
               ),
               Arrays.asList(
-                   new Expression(new ArrayList<Op>(Arrays.asList(
+                   new Expression(new ArrayList<>(Arrays.asList(
                            new Op.Value(new Term.Variable(syms.insert("date"))),
                            new Op.Value(new Term.Date(t2_timestamp)),
                            new Op.Binary(Op.BinaryOp.LessOrEqual)
                    ))),
-                   new Expression(new ArrayList<Op>(Arrays.asList(
+                   new Expression(new ArrayList<>(Arrays.asList(
                            new Op.Value(new Term.Variable(syms.insert("date"))),
                            new Op.Value(new Term.Date(0)),
                            new Op.Binary(Op.BinaryOp.GreaterOrEqual)
@@ -300,16 +300,16 @@ public class WorldTest {
                       new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("date")), new Term.Variable(syms.insert("val"))))
               ),
               Arrays.asList(
-                      new Expression(new ArrayList<Op>(Arrays.asList(
+                      new Expression(new ArrayList<>(Arrays.asList(
                               new Op.Value(new Term.Variable(syms.insert("date"))),
                               new Op.Value(new Term.Date(t2_timestamp)),
                               new Op.Binary(Op.BinaryOp.GreaterOrEqual)
                       ))),
-                     new Expression(new ArrayList<Op>(Arrays.asList(
-                              new Op.Value(new Term.Variable(syms.insert("date"))),
-                              new Op.Value(new Term.Date(0)),
-                              new Op.Binary(Op.BinaryOp.GreaterOrEqual)
-                      )))
+                     new Expression(new ArrayList<>(Arrays.asList(
+                             new Op.Value(new Term.Variable(syms.insert("date"))),
+                             new Op.Value(new Term.Date(0)),
+                             new Op.Binary(Op.BinaryOp.GreaterOrEqual)
+                     )))
               )
       );
 
@@ -346,7 +346,7 @@ public class WorldTest {
                       Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
               ),
               List.of(
-                      new Expression(new ArrayList<Op>(Arrays.asList(
+                      new Expression(new ArrayList<>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Integer(0L), new Term.Integer(1L))))),
                               new Op.Value(new Term.Variable(syms.insert("int"))),
                               new Op.Binary(Op.BinaryOp.Contains)
@@ -370,7 +370,7 @@ public class WorldTest {
               List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))
               ),
               List.of(
-                      new Expression(new ArrayList<Op>(Arrays.asList(
+                      new Expression(new ArrayList<>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(new Term.Str(abc_sym_id), new Term.Str(ghi_sym_id))))),
                               new Op.Value(new Term.Variable(syms.insert("sym"))),
                               new Op.Binary(Op.BinaryOp.Contains),
@@ -392,7 +392,7 @@ public class WorldTest {
               new Predicate(string_set, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str")))),
               List.of(new Predicate(x, Arrays.asList(new Term.Variable(syms.insert("sym")), new Term.Variable(syms.insert("int")), new Term.Variable(syms.insert("str"))))),
               List.of(
-                      new Expression(new ArrayList<Op>(Arrays.asList(
+                      new Expression(new ArrayList<>(Arrays.asList(
                               new Op.Value(new Term.Set(new HashSet<>(Arrays.asList(syms.add("test"), syms.add("aaa"))))),
                               new Op.Value(new Term.Variable(syms.insert("str"))),
                               new Op.Binary(Op.BinaryOp.Contains)

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -227,10 +227,8 @@ public class WorldTest {
         assertEquals(expected, res);
 
         res = testSuffix(w, syms, suff, route, "example.com");
-        for (Iterator<Fact> it = res.stream().iterator(); it.hasNext(); ) {
-            Fact f = it.next();
-            System.out.println("\t" + syms.print_fact(f));
-        }
+        res.stream().forEach(fact -> System.out.println("\t" + syms.print_fact(fact)));
+
         expected = new FactSet(new Origin(0), new HashSet<>(Arrays.asList(new Fact(new Predicate(suff,
                         Arrays.asList(
                                 app_0,

--- a/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/datalog/WorldTest.java
@@ -414,8 +414,6 @@ public class WorldTest {
       final World w = new World();
       final SymbolTable syms = new SymbolTable();
 
-      final Term authority = syms.add("authority");
-      final Term ambient = syms.add("ambient");
       final long resource = syms.insert("resource");
       final long operation = syms.insert("operation");
       final long right = syms.insert("right");

--- a/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
@@ -8,12 +8,12 @@ import org.biscuitsec.biscuit.token.builder.Term;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import static org.biscuitsec.biscuit.token.builder.Utils.constrained_rule;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AuthorizerTest {
 
@@ -25,12 +25,12 @@ public class AuthorizerTest {
         assertEquals(1, policies.size());
 
         authorizer.add_policy(new Policy(
-                Arrays.asList(
+                List.of(
                         constrained_rule(
                                 "deny",
                                 new ArrayList<>(),
                                 new ArrayList<>(),
-                                Arrays.asList(new Expression.Value(new Term.Bool(true)))
+                                List.of(new Expression.Value(new Term.Bool(true)))
                         )
                 ), Policy.Kind.Deny));
         assertEquals(2, policies.size());
@@ -63,7 +63,7 @@ public class AuthorizerTest {
         assertEquals(123, ((Term.Integer) idTerm).getValue());
 
         Term enabledTerm = queryFirstResult(authorizer, "enabledfact($name) <- enabled($name)");
-        assertEquals(true, ((Term.Bool) enabledTerm).getValue());
+        assertTrue(((Term.Bool) enabledTerm).getValue());
 
         Term permsTerm = queryFirstResult(authorizer, "permsfact($name) <- perms($name)");
         assertEquals(

--- a/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
@@ -305,9 +305,7 @@ public class BiscuitTest {
         Error e = (Error) Try.of(v4::authorize).getCause();
 
         out.println(v4.print_world());
-        for (FailedCheck f : e.failed_checks().get()) {
-            out.println(f.toString());
-        }
+        e.failed_checks().get().stream().forEach(fc -> out.println(fc.toString()));
         assertEquals(
                 new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
                         new FailedCheck.FailedBlock(1, 0, "check if resource($resource), $resource.starts_with(\"/folder1/\")"),

--- a/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
@@ -1,19 +1,14 @@
 package org.biscuitsec.biscuit.token;
 
+import io.vavr.control.Option;
+import io.vavr.control.Try;
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
 import org.biscuitsec.biscuit.error.Error;
 import org.biscuitsec.biscuit.error.FailedCheck;
 import org.biscuitsec.biscuit.error.LogicError;
 import org.biscuitsec.biscuit.token.builder.Block;
-
-import io.vavr.control.Option;
-import io.vavr.control.Try;
-
 import org.junit.jupiter.api.Test;
-
-import static java.lang.System.out;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -21,10 +16,14 @@ import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
+import static java.lang.System.out;
 import static org.biscuitsec.biscuit.crypto.TokenSignature.hex;
 import static org.biscuitsec.biscuit.token.builder.Utils.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BiscuitTest {
 
@@ -671,7 +670,7 @@ public class BiscuitTest {
 
         try {
             authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
-        } catch(Error.FailedLogic e) {
+        } catch (Error.FailedLogic e) {
             e.printStackTrace(out);
             assertEquals(new Error.FailedLogic(new LogicError.Unauthorized(
                     new LogicError.MatchedPolicy.Allow(0),

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -45,7 +45,7 @@ class SamplesTest {
         Sample sample = gson.fromJson(new InputStreamReader(new BufferedInputStream(inputStream)), Sample.class);
         PublicKey publicKey = new PublicKey(Schema.PublicKey.Algorithm.Ed25519, sample.root_public_key);
         KeyPair keyPair = new KeyPair(sample.root_private_key);
-        return sample.testcases.stream().map(t -> process_testcase(t, publicKey, keyPair));
+        return sample.testcases.stream().map(t -> processTestcase(t, publicKey, keyPair));
     }
 
     void compareBlocks(KeyPair root, List<Block> sampleBlocks, Biscuit token) throws Error {
@@ -105,7 +105,7 @@ class SamplesTest {
         return newSampleToken;
     }
 
-    DynamicTest process_testcase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
+    DynamicTest processTestcase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
         return DynamicTest.dynamicTest(testCase.title + ": " + testCase.filename, () -> {
             System.out.println("Testcase name: \"" + testCase.title + "\"");
             System.out.println("filename: \"" + testCase.filename + "\"");

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -354,10 +354,10 @@ class SamplesTest {
     }
 
     private class World {
-        List<FactSet> facts;
-        List<RuleSet> rules;
-        List<CheckSet> checks;
-        List<String> policies;
+        final List<FactSet> facts;
+        final List<RuleSet> rules;
+        final List<CheckSet> checks;
+        final List<String> policies;
 
         public World(List<FactSet> facts, List<RuleSet> rules, List<CheckSet> checks, List<String> policies) {
             this.facts = facts;
@@ -447,8 +447,8 @@ class SamplesTest {
     }
 
     private class FactSet {
-        List<Long> origin;
-        List<String> facts;
+        final List<Long> origin;
+        final List<String> facts;
 
         public FactSet(List<Long> origin, List<String> facts) {
             this.origin = origin;
@@ -494,7 +494,7 @@ class SamplesTest {
 
     private class RuleSet implements Comparable<RuleSet> {
         Long origin;
-        List<String> rules;
+        final List<String> rules;
 
         public RuleSet(Long origin, List<String> rules) {
             this.origin = origin;
@@ -549,7 +549,7 @@ class SamplesTest {
 
     private class CheckSet implements Comparable<CheckSet> {
         Long origin;
-        List<String> checks;
+        final List<String> checks;
 
         public CheckSet(Long origin, List<String> checks) {
             this.origin = origin;

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -93,9 +93,8 @@ class SamplesTest {
         System.out.println("deserialized block: ");
         System.out.println(tokenBlock.print(newSampleToken.symbols));
 
-        SymbolTable tokenBlockSymbols = tokenSymbols;
         SymbolTable generatedBlockSymbols = newSampleToken.symbols;
-        assertEquals(generatedSampleBlock.printCode(generatedBlockSymbols), tokenBlock.printCode(tokenBlockSymbols));
+        assertEquals(generatedSampleBlock.printCode(generatedBlockSymbols), tokenBlock.printCode(tokenSymbols));
 
         /* FIXME: to generate the same sample block, we need the samples to provide the external private key
         assertEquals(generatedSampleBlock, tokenBlock);

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -161,9 +161,7 @@ class SamplesTest {
                                 authorizer.add_check(f);
                             } else if (f.startsWith("allow if") || f.startsWith("deny if")) {
                                 authorizer.add_policy(f);
-                            } else if (f.startsWith("revocation_id")) {
-                                // do nothing
-                            } else {
+                            } else if (!f.startsWith("revocation_id")) {
                                 authorizer.add_fact(f);
                             }
                         }

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -227,7 +227,7 @@ class SamplesTest {
         });
     }
 
-    private class Block {
+    private static class Block {
         List<String> symbols;
         String code;
         List<String> public_keys;
@@ -282,7 +282,7 @@ class SamplesTest {
         }
     }
 
-    private class TestCase {
+    private static class TestCase {
         String title;
 
         public String getTitle() {
@@ -322,7 +322,7 @@ class SamplesTest {
         }
     }
 
-    private class Sample {
+    private static class Sample {
         String root_private_key;
 
         public String getRoot_public_key() {
@@ -353,7 +353,7 @@ class SamplesTest {
         }
     }
 
-    private class World {
+    private static class World {
         final List<FactSet> facts;
         final List<RuleSet> rules;
         final List<CheckSet> checks;
@@ -446,7 +446,7 @@ class SamplesTest {
         }
     }
 
-    private class FactSet {
+    private static class FactSet {
         final List<Long> origin;
         final List<String> facts;
 
@@ -492,7 +492,7 @@ class SamplesTest {
         }
     }
 
-    private class RuleSet implements Comparable<RuleSet> {
+    private static class RuleSet implements Comparable<RuleSet> {
         Long origin;
         final List<String> rules;
 
@@ -547,7 +547,7 @@ class SamplesTest {
         }
     }
 
-    private class CheckSet implements Comparable<CheckSet> {
+    private static class CheckSet implements Comparable<CheckSet> {
         Long origin;
         final List<String> checks;
 

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -227,33 +227,9 @@ class SamplesTest {
 
     private static class Block {
         String code;
-        List<String> public_keys;
-        String external_key;
 
         public String getCode() {
             return code;
-        }
-
-        public List<PublicKey> getPublicKeys() {
-            return this.public_keys.stream()
-                    .map(pk ->
-                            Parser.publicKey(pk).fold(e -> {
-                                throw new IllegalArgumentException(e.toString());
-                            }, r -> r._2)
-                    )
-                    .collect(Collectors.toList());
-        }
-
-        public Option<PublicKey> getExternalKey() {
-            if (this.external_key != null) {
-                PublicKey externalKey = Parser.publicKey(this.external_key)
-                        .fold(e -> {
-                            throw new IllegalArgumentException(e.toString());
-                        }, r -> r._2);
-                return Option.of(externalKey);
-            } else {
-                return Option.none();
-            }
         }
     }
 

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -119,7 +119,7 @@ class SamplesTest {
                 JsonObject expected_result = validation.getAsJsonObject("result");
                 String[] authorizer_facts = validation.getAsJsonPrimitive("authorizer_code").getAsString().split(";");
                 Either<Throwable, Long> res = Try.of(() -> {
-                    inputStream.read(data);
+                    int ignoreNumBytesRead = inputStream.read(data);
                     Biscuit token = Biscuit.from_bytes(data, publicKey);
                     assertArrayEquals(token.serialize(), data);
 

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -158,7 +158,7 @@ class SamplesTest {
                     System.out.println(token.print());
                     for (String f : authorizer_facts) {
                         f = f.trim();
-                        if (f.length() > 0) {
+                        if (!f.isEmpty()) {
                             if (f.startsWith("check if") || f.startsWith("check all")) {
                                 authorizer.add_check(f);
                             } else if (f.startsWith("allow if") || f.startsWith("deny if")) {

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -371,10 +371,10 @@ class SamplesTest {
             this.facts = authorizer.facts().facts().entrySet().stream().map(entry -> {
                 ArrayList<Long> origin = new ArrayList<>(entry.getKey().inner);
                 Collections.sort(origin);
-                ArrayList<String> facts = new ArrayList<>(entry.getValue().stream()
-                        .map(f -> authorizer.symbols.print_fact(f)).collect(Collectors.toList()));
-                Collections.sort(facts);
-
+                ArrayList<String> facts = entry.getValue().stream()
+                        .map(f -> authorizer.symbols.print_fact(f))
+                        .sorted()
+                        .collect(Collectors.toCollection(ArrayList::new));
                 return new FactSet(origin, facts);
             }).collect(Collectors.toList());
 

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -401,7 +401,7 @@ class SamplesTest {
 
             this.checks = authorizer.checks().stream()
                     .map((Tuple2<Long, List<Check>> t) -> {
-                        List<String> checks1 = t._2.stream().map(c -> c.toString()).collect(Collectors.toList());
+                        List<String> checks1 = t._2.stream().map(Check::toString).collect(Collectors.toList());
                         Collections.sort(checks1);
                         if (t._1 == null) {
                             return new CheckSet(checks1);
@@ -409,7 +409,7 @@ class SamplesTest {
                             return new CheckSet(t._1, checks1);
                         }
                     }).collect(Collectors.toList());
-            this.policies = authorizer.policies().stream().map(p -> p.toString()).collect(Collectors.toList());
+            this.policies = authorizer.policies().stream().map(Policy::toString).collect(Collectors.toList());
             Collections.sort(this.rules);
             Collections.sort(this.checks);
         }

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -61,8 +61,6 @@ class SamplesTest {
     }
 
     private Biscuit compareBlock(KeyPair root, Option<Biscuit> sampleToken, long sampleBlockIndex, Block sampleBlock, org.biscuitsec.biscuit.token.Block tokenBlock, SymbolTable tokenSymbols) throws Error {
-        Option<PublicKey> sampleExternalKey = sampleBlock.getExternalKey();
-        List<PublicKey> samplePublicKeys = sampleBlock.getPublicKeys();
         String sampleDatalog = sampleBlock.getCode().replace("\"", "\\\"");
 
         Either<Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>>, org.biscuitsec.biscuit.token.builder.Block> outputSample = Parser.datalog(sampleBlockIndex, sampleDatalog);
@@ -228,25 +226,12 @@ class SamplesTest {
     }
 
     private static class Block {
-        List<String> symbols;
         String code;
         List<String> public_keys;
         String external_key;
 
-        public List<String> getSymbols() {
-            return symbols;
-        }
-
-        public void setSymbols(List<String> symbols) {
-            this.symbols = symbols;
-        }
-
         public String getCode() {
             return code;
-        }
-
-        public void setCode(String code) {
-            this.code = code;
         }
 
         public List<PublicKey> getPublicKeys() {
@@ -256,12 +241,6 @@ class SamplesTest {
                                 throw new IllegalArgumentException(e.toString());
                             }, r -> r._2)
                     )
-                    .collect(Collectors.toList());
-        }
-
-        public void setPublicKeys(List<PublicKey> publicKeys) {
-            this.public_keys = publicKeys.stream()
-                    .map(PublicKey::toString)
                     .collect(Collectors.toList());
         }
 
@@ -276,81 +255,19 @@ class SamplesTest {
                 return Option.none();
             }
         }
-
-        public void setExternalKey(Option<PublicKey> externalKey) {
-            this.external_key = externalKey.map(PublicKey::toString).getOrElse((String) null);
-        }
     }
 
     private static class TestCase {
         String title;
-
-        public String getTitle() {
-            return title;
-        }
-
-        public void setTitle(String title) {
-            this.title = title;
-        }
-
         String filename;
         List<Block> token;
         JsonElement validations;
-
-        public String getFilename() {
-            return filename;
-        }
-
-        public void setFilename(String filename) {
-            this.filename = filename;
-        }
-
-        public List<Block> getToken() {
-            return token;
-        }
-
-        public void setTokens(List<Block> token) {
-            this.token = token;
-        }
-
-        public JsonElement getValidations() {
-            return validations;
-        }
-
-        public void setValidations(JsonElement validations) {
-            this.validations = validations;
-        }
     }
 
     private static class Sample {
         String root_private_key;
-
-        public String getRoot_public_key() {
-            return root_public_key;
-        }
-
-        public void setRoot_public_key(String root_public_key) {
-            this.root_public_key = root_public_key;
-        }
-
         String root_public_key;
         List<TestCase> testcases;
-
-        public String getRoot_private_key() {
-            return root_private_key;
-        }
-
-        public void setRoot_private_key(String root_private_key) {
-            this.root_private_key = root_private_key;
-        }
-
-        public List<TestCase> getTestcases() {
-            return testcases;
-        }
-
-        public void setTestcases(List<TestCase> testcases) {
-            this.testcases = testcases;
-        }
     }
 
     private static class World {

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -392,15 +392,17 @@ class SamplesTest {
             }
             List<RuleSet> rulesets = rules.entrySet().stream()
                     .map(entry -> new RuleSet(entry.getKey(), entry.getValue()))
+                    .sorted()
                     .collect(Collectors.toList());
-            Collections.sort(rulesets);
 
             this.rules = rulesets;
 
             this.checks = authorizer.checks().stream()
                     .map((Tuple2<Long, List<Check>> t) -> {
-                        List<String> checks1 = t._2.stream().map(Check::toString).collect(Collectors.toList());
-                        Collections.sort(checks1);
+                        List<String> checks1 = t._2.stream()
+                                .map(Check::toString)
+                                .sorted()
+                                .collect(Collectors.toList());
                         if (t._1 == null) {
                             return new CheckSet(checks1);
                         } else {

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -120,6 +120,7 @@ class SamplesTest {
                     Biscuit token = Biscuit.from_bytes(data, publicKey);
                     assertArrayEquals(token.serialize(), data);
 
+                    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
                     List<org.biscuitsec.biscuit.token.Block> allBlocks = new ArrayList<>();
                     allBlocks.add(token.authority);
                     allBlocks.addAll(token.blocks);
@@ -243,6 +244,7 @@ class SamplesTest {
     private static class Sample {
         String root_private_key;
         String root_public_key;
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         List<TestCase> testcases;
     }
 

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -110,7 +110,7 @@ class SamplesTest {
             System.out.println("Testcase name: \"" + testCase.title + "\"");
             System.out.println("filename: \"" + testCase.filename + "\"");
             InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("samples/" + testCase.filename);
-            byte[] data = new byte[inputStream.available()];
+            byte[] data = new byte[requireNonNull(inputStream, "InputStream cannot be null").available()];
 
             for (Map.Entry<String, JsonElement> validationEntry : testCase.validations.getAsJsonObject().entrySet()) {
                 String validationName = validationEntry.getKey();

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -183,8 +183,6 @@ class SamplesTest {
                             assertEquals(world.rules, authorizerWorld.rules);
                             assertEquals(world.checks, authorizerWorld.checks);
                             assertEquals(world.policies, authorizerWorld.policies);
-
-
                         }
 
                         return authorizeResult;

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -60,6 +60,55 @@ class SamplesTest {
         return sample.testcases.stream().map(t -> processTestCase(t, publicKey, keyPair));
     }
 
+    private DynamicTest processTestCase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
+        return DynamicTest.dynamicTest(testCase.title + ": " + testCase.filename, () -> {
+            out.println("Testcase name: \"" + testCase.title + "\"");
+            out.println("filename: \"" + testCase.filename + "\"");
+            InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("samples/" + testCase.filename);
+            byte[] data = new byte[requireNonNull(inputStream, "InputStream cannot be null").available()];
+
+            for (Map.Entry<String, JsonElement> validationEntry : testCase.validations.getAsJsonObject().entrySet()) {
+                String validationName = validationEntry.getKey();
+                JsonObject validation = validationEntry.getValue().getAsJsonObject();
+
+                JsonObject validationResult = validation.getAsJsonObject("result");
+                String[] authorizerFacts = validation.getAsJsonPrimitive("authorizer_code").getAsString().split(";");
+
+                Either<Throwable, Long> authorizerResult = Try.of(() -> {
+                    int ignoreNumBytesRead = inputStream.read(data);
+                    Biscuit token = Biscuit.from_bytes(data, publicKey);
+                    assertArrayEquals(token.serialize(), data);
+
+                    compareBlocks(privateKey, testCase.token, token);
+                    checkAuthorityBlockSerialization(token);
+                    checkTokenBlockSerialization(token);
+                    checkRevocationIdentifiers(token, validation);
+
+                    // TODO Add check of the token
+
+                    out.println(token.print());
+                    Authorizer authorizer = token.authorizer();
+                    checkAuthorizerFacts(authorizer, authorizerFacts);
+                    return attemptAuthorization(authorizer, validation);
+                }).toEither();
+
+                if (validationResult.has("Ok")) {
+                    processValidationPassResult(validationResult, validationName, authorizerResult);
+                } else {
+                    processValidationErrorResult(validationResult, validationName, authorizerResult);
+                }
+            }
+
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    System.err.printf("Unable to close InputStream", e);
+                }
+            }
+        });
+    }
+
     private void compareBlocks(KeyPair root, List<Block> sampleBlocks, Biscuit token) throws Error {
         assertEquals(sampleBlocks.size(), 1 + token.blocks.size());
         Option<Biscuit> sampleToken = Option.none();
@@ -116,55 +165,6 @@ class SamplesTest {
         */
 
         return newSampleToken;
-    }
-
-    private DynamicTest processTestCase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
-        return DynamicTest.dynamicTest(testCase.title + ": " + testCase.filename, () -> {
-            out.println("Testcase name: \"" + testCase.title + "\"");
-            out.println("filename: \"" + testCase.filename + "\"");
-            InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("samples/" + testCase.filename);
-            byte[] data = new byte[requireNonNull(inputStream, "InputStream cannot be null").available()];
-
-            for (Map.Entry<String, JsonElement> validationEntry : testCase.validations.getAsJsonObject().entrySet()) {
-                String validationName = validationEntry.getKey();
-                JsonObject validation = validationEntry.getValue().getAsJsonObject();
-
-                JsonObject validationResult = validation.getAsJsonObject("result");
-                String[] authorizerFacts = validation.getAsJsonPrimitive("authorizer_code").getAsString().split(";");
-
-                Either<Throwable, Long> authorizerResult = Try.of(() -> {
-                    int ignoreNumBytesRead = inputStream.read(data);
-                    Biscuit token = Biscuit.from_bytes(data, publicKey);
-                    assertArrayEquals(token.serialize(), data);
-
-                    compareBlocks(privateKey, testCase.token, token);
-                    checkAuthorityBlockSerialization(token);
-                    checkTokenBlockSerialization(token);
-                    checkRevocationIdentifiers(token, validation);
-
-                    // TODO Add check of the token
-
-                    out.println(token.print());
-                    Authorizer authorizer = token.authorizer();
-                    checkAuthorizerFacts(authorizer, authorizerFacts);
-                    return attemptAuthorization(authorizer, validation);
-                }).toEither();
-
-                if (validationResult.has("Ok")) {
-                    processValidationPassResult(validationResult, validationName, authorizerResult);
-                } else {
-                    processValidationErrorResult(validationResult, validationName, authorizerResult);
-                }
-            }
-
-            if (inputStream != null) {
-                try {
-                    inputStream.close();
-                } catch (IOException e) {
-                    System.err.printf("Unable to close InputStream", e);
-                }
-            }
-        });
     }
 
     private Long attemptAuthorization(Authorizer authorizer, JsonObject validation) throws Exception {

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNull;
 import static org.biscuitsec.biscuit.token.Block.from_bytes;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +43,9 @@ class SamplesTest {
         InputStream inputStream =
                 Thread.currentThread().getContextClassLoader().getResourceAsStream("samples/samples.json");
         Gson gson = new Gson();
-        Sample sample = gson.fromJson(new InputStreamReader(new BufferedInputStream(inputStream)), Sample.class);
+        Sample sample = gson.fromJson(new InputStreamReader(
+                        new BufferedInputStream(requireNonNull(inputStream, "InputStream cannot be null"))),
+                Sample.class);
         PublicKey publicKey = new PublicKey(Schema.PublicKey.Algorithm.Ed25519, sample.root_public_key);
         KeyPair keyPair = new KeyPair(sample.root_private_key);
         return sample.testcases.stream().map(t -> processTestcase(t, publicKey, keyPair));

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -389,12 +389,11 @@ class SamplesTest {
             for (Map.Entry<Long, List<String>> entry : rules.entrySet()) {
                 Collections.sort(entry.getValue());
             }
-            List<RuleSet> rulesets = rules.entrySet().stream()
+
+            this.rules = rules.entrySet().stream()
                     .map(entry -> new RuleSet(entry.getKey(), entry.getValue()))
                     .sorted()
                     .collect(Collectors.toList());
-
-            this.rules = rulesets;
 
             this.checks = authorizer.checks().stream()
                     .map((Tuple2<Long, List<Check>> t) -> {

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -48,7 +48,7 @@ class SamplesTest {
         return sample.testcases.stream().map(t -> processTestcase(t, publicKey, keyPair));
     }
 
-    void compareBlocks(KeyPair root, List<Block> sampleBlocks, Biscuit token) throws Error {
+    private void compareBlocks(KeyPair root, List<Block> sampleBlocks, Biscuit token) throws Error {
         assertEquals(sampleBlocks.size(), 1 + token.blocks.size());
         Option<Biscuit> sampleToken = Option.none();
         Biscuit b = compareBlock(root, sampleToken, 0, sampleBlocks.get(0), token.authority, token.symbols);
@@ -60,7 +60,7 @@ class SamplesTest {
         }
     }
 
-    Biscuit compareBlock(KeyPair root, Option<Biscuit> sampleToken, long sampleBlockIndex, Block sampleBlock, org.biscuitsec.biscuit.token.Block tokenBlock, SymbolTable tokenSymbols) throws Error {
+    private Biscuit compareBlock(KeyPair root, Option<Biscuit> sampleToken, long sampleBlockIndex, Block sampleBlock, org.biscuitsec.biscuit.token.Block tokenBlock, SymbolTable tokenSymbols) throws Error {
         Option<PublicKey> sampleExternalKey = sampleBlock.getExternalKey();
         List<PublicKey> samplePublicKeys = sampleBlock.getPublicKeys();
         String sampleDatalog = sampleBlock.getCode().replace("\"", "\\\"");
@@ -105,7 +105,7 @@ class SamplesTest {
         return newSampleToken;
     }
 
-    DynamicTest processTestcase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
+    private DynamicTest processTestcase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
         return DynamicTest.dynamicTest(testCase.title + ": " + testCase.filename, () -> {
             System.out.println("Testcase name: \"" + testCase.title + "\"");
             System.out.println("filename: \"" + testCase.filename + "\"");
@@ -230,7 +230,7 @@ class SamplesTest {
         });
     }
 
-    class Block {
+    private class Block {
         List<String> symbols;
         String code;
         List<String> public_keys;
@@ -285,7 +285,7 @@ class SamplesTest {
         }
     }
 
-    class TestCase {
+    private class TestCase {
         String title;
 
         public String getTitle() {
@@ -325,7 +325,7 @@ class SamplesTest {
         }
     }
 
-    class Sample {
+    private class Sample {
         String root_private_key;
 
         public String getRoot_public_key() {
@@ -356,7 +356,7 @@ class SamplesTest {
         }
     }
 
-    class World {
+    private class World {
         List<FactSet> facts;
         List<RuleSet> rules;
         List<CheckSet> checks;
@@ -448,7 +448,7 @@ class SamplesTest {
         }
     }
 
-    class FactSet {
+    private class FactSet {
         List<Long> origin;
         List<String> facts;
 
@@ -494,7 +494,7 @@ class SamplesTest {
         }
     }
 
-    class RuleSet implements Comparable<RuleSet> {
+    private class RuleSet implements Comparable<RuleSet> {
         Long origin;
         List<String> rules;
 
@@ -549,7 +549,7 @@ class SamplesTest {
         }
     }
 
-    class CheckSet implements Comparable<CheckSet> {
+    private class CheckSet implements Comparable<CheckSet> {
         Long origin;
         List<String> checks;
 
@@ -608,5 +608,4 @@ class SamplesTest {
                     '}';
         }
     }
-
 }

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.System.out;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 import static org.biscuitsec.biscuit.token.Block.from_bytes;
@@ -93,10 +94,10 @@ class SamplesTest {
             generatedSampleBlock = newSampleToken.blocks.get((int) sampleBlockIndex - 1);
         }
 
-        System.out.println("generated block: ");
-        System.out.println(generatedSampleBlock.print(newSampleToken.symbols));
-        System.out.println("deserialized block: ");
-        System.out.println(tokenBlock.print(newSampleToken.symbols));
+        out.println("generated block: ");
+        out.println(generatedSampleBlock.print(newSampleToken.symbols));
+        out.println("deserialized block: ");
+        out.println(tokenBlock.print(newSampleToken.symbols));
 
         SymbolTable generatedBlockSymbols = newSampleToken.symbols;
         assertEquals(generatedSampleBlock.printCode(generatedBlockSymbols), tokenBlock.printCode(tokenSymbols));
@@ -111,8 +112,8 @@ class SamplesTest {
 
     private DynamicTest processTestcase(final TestCase testCase, final PublicKey publicKey, final KeyPair privateKey) {
         return DynamicTest.dynamicTest(testCase.title + ": " + testCase.filename, () -> {
-            System.out.println("Testcase name: \"" + testCase.title + "\"");
-            System.out.println("filename: \"" + testCase.filename + "\"");
+            out.println("Testcase name: \"" + testCase.title + "\"");
+            out.println("filename: \"" + testCase.filename + "\"");
             InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("samples/" + testCase.filename);
             byte[] data = new byte[requireNonNull(inputStream, "InputStream cannot be null").available()];
 
@@ -135,8 +136,8 @@ class SamplesTest {
                     compareBlocks(privateKey, testCase.token, token);
 
                     byte[] ser_block_authority = token.authority.to_bytes().get();
-                    System.out.println(Arrays.toString(ser_block_authority));
-                    System.out.println(Arrays.toString(token.serializedBiscuit.authority.block));
+                    out.println(Arrays.toString(ser_block_authority));
+                    out.println(Arrays.toString(token.serializedBiscuit.authority.block));
                     org.biscuitsec.biscuit.token.Block deser_block_authority = from_bytes(ser_block_authority, token.authority.externalKey).get();
                     assertEquals(token.authority.print(token.symbols), deser_block_authority.print(token.symbols));
                     assert (Arrays.equals(ser_block_authority, token.serializedBiscuit.authority.block));
@@ -160,7 +161,7 @@ class SamplesTest {
                     // TODO Add check of the token
 
                     Authorizer authorizer = token.authorizer();
-                    System.out.println(token.print());
+                    out.println(token.print());
                     for (String f : authorizer_facts) {
                         f = f.trim();
                         if (!f.isEmpty()) {
@@ -173,7 +174,7 @@ class SamplesTest {
                             }
                         }
                     }
-                    System.out.println(authorizer.print_world());
+                    out.println(authorizer.print_world());
                     try {
                         Long authorizeResult = authorizer.authorize(runLimits);
 
@@ -208,7 +209,7 @@ class SamplesTest {
 
                 if (expected_result.has("Ok")) {
                     if (res.isLeft()) {
-                        System.out.println("validation '" + validationName + "' expected result Ok(" + expected_result.getAsJsonPrimitive("Ok").getAsLong() + "), got error");
+                        out.println("validation '" + validationName + "' expected result Ok(" + expected_result.getAsJsonPrimitive("Ok").getAsLong() + "), got error");
                         throw res.getLeft();
                     } else {
                         assertEquals(expected_result.getAsJsonPrimitive("Ok").getAsLong(), res.get());
@@ -217,7 +218,7 @@ class SamplesTest {
                     if (res.isLeft()) {
                         if (res.getLeft() instanceof Error) {
                             Error e = (Error) res.getLeft();
-                            System.out.println("validation '" + validationName + "' got error: " + e);
+                            out.println("validation '" + validationName + "' got error: " + e);
                             JsonElement err_json = e.toJson();
                             assertEquals(expected_result.get("Err"), err_json);
                         } else {

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 
 import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ThirdPartyTest {
     @Test
@@ -30,11 +29,11 @@ public class ThirdPartyTest {
 
         KeyPair root = new KeyPair(rng);
         KeyPair external = new KeyPair(rng);
-        out.println("external: ed25519/"+external.public_key().toHex());
+        out.println("external: ed25519/" + external.public_key().toHex());
 
         Block authorityBuilder = new Block();
         authorityBuilder.add_fact("right(\"read\")");
-        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/" + external.public_key().toHex());
 
         Biscuit b1 = Biscuit.make(rng, root, authorityBuilder.build());
         ThirdPartyBlockRequest request = b1.thirdPartyRequest();
@@ -97,35 +96,35 @@ public class ThirdPartyTest {
 
         Block authorityBuilder = new Block();
         authorityBuilder.add_fact("right(\"read\")");
-        authorityBuilder.add_check("check if first(\"admin\") trusting ed25519/"+external1.public_key().toHex());
+        authorityBuilder.add_check("check if first(\"admin\") trusting ed25519/" + external1.public_key().toHex());
 
-        org.biscuitsec.biscuit.token.Block authority_block =  authorityBuilder.build();
+        org.biscuitsec.biscuit.token.Block authority_block = authorityBuilder.build();
         out.println(authority_block);
         Biscuit b1 = Biscuit.make(rng, root, authority_block);
-        out.println("TOKEN: "+b1.print());
+        out.println("TOKEN: " + b1.print());
 
         ThirdPartyBlockRequest request1 = b1.thirdPartyRequest();
         Block builder = new Block();
         builder.add_fact("first(\"admin\")");
         builder.add_fact("second(\"A\")");
-        builder.add_check("check if third(3) trusting ed25519/"+external2.public_key().toHex());
+        builder.add_check("check if third(3) trusting ed25519/" + external2.public_key().toHex());
         ThirdPartyBlockContents blockResponse = request1.createBlock(external1, builder).get();
         Biscuit b2 = b1.appendThirdPartyBlock(external1.public_key(), blockResponse);
         byte[] data = b2.serialize();
         Biscuit deser2 = Biscuit.from_bytes(data, root.public_key());
         assertEquals(b2.print(), deser2.print());
-        out.println("TOKEN: "+deser2.print());
+        out.println("TOKEN: " + deser2.print());
 
         ThirdPartyBlockRequest request2 = deser2.thirdPartyRequest();
         Block builder2 = new Block();
         builder2.add_fact("third(3)");
-        builder2.add_check("check if fourth(1) trusting ed25519/"+external3.public_key().toHex()+", ed25519/"+external1.public_key().toHex());
+        builder2.add_check("check if fourth(1) trusting ed25519/" + external3.public_key().toHex() + ", ed25519/" + external1.public_key().toHex());
         ThirdPartyBlockContents blockResponse2 = request2.createBlock(external2, builder2).get();
         Biscuit b3 = deser2.appendThirdPartyBlock(external2.public_key(), blockResponse2);
         byte[] data2 = b3.serialize();
         Biscuit deser3 = Biscuit.from_bytes(data2, root.public_key());
         assertEquals(b3.print(), deser3.print());
-        out.println("TOKEN: "+deser3.print());
+        out.println("TOKEN: " + deser3.print());
 
 
         ThirdPartyBlockRequest request3 = deser3.thirdPartyRequest();
@@ -137,20 +136,20 @@ public class ThirdPartyTest {
         byte[] data3 = b4.serialize();
         Biscuit deser4 = Biscuit.from_bytes(data3, root.public_key());
         assertEquals(b4.print(), deser4.print());
-        out.println("TOKEN: "+deser4.print());
+        out.println("TOKEN: " + deser4.print());
 
         out.println("will check the token for resource=file1");
         Authorizer authorizer = deser4.authorizer();
         authorizer.add_fact("resource(\"file1\")");
         authorizer.add_policy("allow if true");
-        out.println("Authorizer world:\n"+authorizer.print_world());
+        out.println("Authorizer world:\n" + authorizer.print_world());
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
 
         out.println("will check the token for resource=file2");
         Authorizer authorizer2 = deser4.authorizer();
         authorizer2.add_fact("resource(\"file2\")");
         authorizer2.add_policy("allow if true");
-        out.println("Authorizer world 2:\n"+authorizer2.print_world());
+        out.println("Authorizer world 2:\n" + authorizer2.print_world());
 
         try {
             authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
@@ -173,11 +172,11 @@ public class ThirdPartyTest {
 
         KeyPair root = new KeyPair(rng);
         KeyPair external = new KeyPair(rng);
-        out.println("external: ed25519/"+external.public_key().toHex());
+        out.println("external: ed25519/" + external.public_key().toHex());
 
         Block authorityBuilder = new Block();
         authorityBuilder.add_fact("right(\"read\")");
-        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/" + external.public_key().toHex());
 
         Biscuit b1 = Biscuit.make(rng, root, authorityBuilder.build());
         ThirdPartyBlockRequest request = b1.thirdPartyRequest();
@@ -199,7 +198,7 @@ public class ThirdPartyTest {
         authorizer.add_fact("resource(\"file1\")");
         authorizer.add_policy("allow if true");
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
-        out.println("Authorizer world:\n"+authorizer.print_world());
+        out.println("Authorizer world:\n" + authorizer.print_world());
 
 
         out.println("will check the token for resource=file2");

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -4,6 +4,7 @@ import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
 import org.biscuitsec.biscuit.error.Error;
 import org.biscuitsec.biscuit.error.FailedCheck;
+import org.biscuitsec.biscuit.error.FailedCheck.FailedBlock;
 import org.biscuitsec.biscuit.token.builder.Block;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import java.util.List;
 
 import static java.lang.System.out;
 import static org.biscuitsec.biscuit.error.LogicError.MatchedPolicy;
+import static org.biscuitsec.biscuit.error.LogicError.MatchedPolicy.*;
 import static org.biscuitsec.biscuit.error.LogicError.Unauthorized;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -73,8 +75,8 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
-                            new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
+                    new Error.FailedLogic(new Unauthorized(new Allow(0), List.of(
+                            new FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);
         }
@@ -157,8 +159,8 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
-                            new FailedCheck.FailedBlock(3, 0, "check if resource(\"file1\")")
+                    new Error.FailedLogic(new Unauthorized(new Allow(0), List.of(
+                            new FailedBlock(3, 0, "check if resource(\"file1\")")
                     ))),
                     e);
         }
@@ -212,8 +214,8 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
-                            new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
+                    new Error.FailedLogic(new Unauthorized(new Allow(0), List.of(
+                            new FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);
         }

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -14,7 +14,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.List;
 
 import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,7 +72,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);
@@ -156,7 +156,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(3, 0, "check if resource(\"file1\")")
                     ))),
                     e);
@@ -211,7 +211,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ThirdPartyTest {
     @Test
-    public void testRoundTrip() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error, IOException {
+    public void testRoundTrip() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error, IOException {
         byte[] seed = {0, 0, 0, 0};
         SecureRandom rng = new SecureRandom(seed);
 
@@ -80,7 +80,7 @@ public class ThirdPartyTest {
     }
 
     @Test
-    public void testPublicKeyInterning() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error {
+    public void testPublicKeyInterning() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error {
         // this makes a deterministic RNG
         SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
         byte[] seed = {0, 0, 0, 0};
@@ -165,7 +165,7 @@ public class ThirdPartyTest {
     }
 
     @Test
-    public void testReusedSymbols() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error {
+    public void testReusedSymbols() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error {
         byte[] seed = {0, 0, 0, 0};
         SecureRandom rng = new SecureRandom(seed);
 

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -4,7 +4,6 @@ import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
 import org.biscuitsec.biscuit.error.Error;
 import org.biscuitsec.biscuit.error.FailedCheck;
-import org.biscuitsec.biscuit.error.LogicError;
 import org.biscuitsec.biscuit.token.builder.Block;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +16,8 @@ import java.time.Duration;
 import java.util.List;
 
 import static java.lang.System.out;
+import static org.biscuitsec.biscuit.error.LogicError.MatchedPolicy;
+import static org.biscuitsec.biscuit.error.LogicError.Unauthorized;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ThirdPartyTest {
@@ -72,7 +73,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
+                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);
@@ -156,7 +157,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
+                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(3, 0, "check if resource(\"file1\")")
                     ))),
                     e);
@@ -211,7 +212,7 @@ public class ThirdPartyTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), List.of(
+                    new Error.FailedLogic(new Unauthorized(new MatchedPolicy.Allow(0), List.of(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
                     ))),
                     e);

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -16,6 +16,7 @@ import java.security.SignatureException;
 import java.time.Duration;
 import java.util.Arrays;
 
+import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,11 +26,11 @@ public class ThirdPartyTest {
         byte[] seed = {0, 0, 0, 0};
         SecureRandom rng = new SecureRandom(seed);
 
-        System.out.println("preparing the authority block");
+        out.println("preparing the authority block");
 
         KeyPair root = new KeyPair(rng);
         KeyPair external = new KeyPair(rng);
-        System.out.println("external: ed25519/"+external.public_key().toHex());
+        out.println("external: ed25519/"+external.public_key().toHex());
 
         Block authority_builder = new Block();
         authority_builder.add_fact("right(\"read\")");
@@ -56,13 +57,13 @@ public class ThirdPartyTest {
         Biscuit deser = Biscuit.from_bytes(data, root.public_key());
         assertEquals(b2.print(), deser.print());
 
-        System.out.println("will check the token for resource=file1");
+        out.println("will check the token for resource=file1");
         Authorizer authorizer = deser.authorizer();
         authorizer.add_fact("resource(\"file1\")");
         authorizer.add_policy("allow if true");
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
 
-        System.out.println("will check the token for resource=file2");
+        out.println("will check the token for resource=file2");
         Authorizer authorizer2 = deser.authorizer();
         authorizer2.add_fact("resource(\"file2\")");
         authorizer2.add_policy("allow if true");
@@ -70,7 +71,7 @@ public class ThirdPartyTest {
         try {
             authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
         } catch (Error e) {
-            System.out.println(e);
+            out.println(e);
             assertEquals(
                     new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
@@ -86,7 +87,7 @@ public class ThirdPartyTest {
         byte[] seed = {0, 0, 0, 0};
         rng.setSeed(seed);
 
-        System.out.println("preparing the authority block");
+        out.println("preparing the authority block");
 
         KeyPair root = new KeyPair(rng);
         KeyPair external1 = new KeyPair(rng);
@@ -99,9 +100,9 @@ public class ThirdPartyTest {
         authority_builder.add_check("check if first(\"admin\") trusting ed25519/"+external1.public_key().toHex());
 
         org.biscuitsec.biscuit.token.Block authority_block =  authority_builder.build();
-        System.out.println(authority_block);
+        out.println(authority_block);
         Biscuit b1 = Biscuit.make(rng, root, authority_block);
-        System.out.println("TOKEN: "+b1.print());
+        out.println("TOKEN: "+b1.print());
 
         ThirdPartyBlockRequest request1 = b1.thirdPartyRequest();
         Block builder = new Block();
@@ -113,7 +114,7 @@ public class ThirdPartyTest {
         byte[] data = b2.serialize();
         Biscuit deser2 = Biscuit.from_bytes(data, root.public_key());
         assertEquals(b2.print(), deser2.print());
-        System.out.println("TOKEN: "+deser2.print());
+        out.println("TOKEN: "+deser2.print());
 
         ThirdPartyBlockRequest request2 = deser2.thirdPartyRequest();
         Block builder2 = new Block();
@@ -124,7 +125,7 @@ public class ThirdPartyTest {
         byte[] data2 = b3.serialize();
         Biscuit deser3 = Biscuit.from_bytes(data2, root.public_key());
         assertEquals(b3.print(), deser3.print());
-        System.out.println("TOKEN: "+deser3.print());
+        out.println("TOKEN: "+deser3.print());
 
 
         ThirdPartyBlockRequest request3 = deser3.thirdPartyRequest();
@@ -136,26 +137,26 @@ public class ThirdPartyTest {
         byte[] data3 = b4.serialize();
         Biscuit deser4 = Biscuit.from_bytes(data3, root.public_key());
         assertEquals(b4.print(), deser4.print());
-        System.out.println("TOKEN: "+deser4.print());
+        out.println("TOKEN: "+deser4.print());
 
 
-        System.out.println("will check the token for resource=file1");
+        out.println("will check the token for resource=file1");
         Authorizer authorizer = deser4.authorizer();
         authorizer.add_fact("resource(\"file1\")");
         authorizer.add_policy("allow if true");
-        System.out.println("Authorizer world:\n"+authorizer.print_world());
+        out.println("Authorizer world:\n"+authorizer.print_world());
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
 
-        System.out.println("will check the token for resource=file2");
+        out.println("will check the token for resource=file2");
         Authorizer authorizer2 = deser4.authorizer();
         authorizer2.add_fact("resource(\"file2\")");
         authorizer2.add_policy("allow if true");
-        System.out.println("Authorizer world 2:\n"+authorizer2.print_world());
+        out.println("Authorizer world 2:\n"+authorizer2.print_world());
 
         try {
             authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
         } catch (Error e) {
-            System.out.println(e);
+            out.println(e);
             assertEquals(
                     new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
                             new FailedCheck.FailedBlock(3, 0, "check if resource(\"file1\")")
@@ -169,11 +170,11 @@ public class ThirdPartyTest {
         byte[] seed = {0, 0, 0, 0};
         SecureRandom rng = new SecureRandom(seed);
 
-        System.out.println("preparing the authority block");
+        out.println("preparing the authority block");
 
         KeyPair root = new KeyPair(rng);
         KeyPair external = new KeyPair(rng);
-        System.out.println("external: ed25519/"+external.public_key().toHex());
+        out.println("external: ed25519/"+external.public_key().toHex());
 
         Block authority_builder = new Block();
         authority_builder.add_fact("right(\"read\")");
@@ -194,15 +195,15 @@ public class ThirdPartyTest {
         Biscuit deser = Biscuit.from_bytes(data, root.public_key());
         assertEquals(b2.print(), deser.print());
 
-        System.out.println("will check the token for resource=file1");
+        out.println("will check the token for resource=file1");
         Authorizer authorizer = deser.authorizer();
         authorizer.add_fact("resource(\"file1\")");
         authorizer.add_policy("allow if true");
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
-        System.out.println("Authorizer world:\n"+authorizer.print_world());
+        out.println("Authorizer world:\n"+authorizer.print_world());
 
 
-        System.out.println("will check the token for resource=file2");
+        out.println("will check the token for resource=file2");
         Authorizer authorizer2 = deser.authorizer();
         authorizer2.add_fact("resource(\"file2\")");
         authorizer2.add_policy("allow if true");
@@ -210,7 +211,7 @@ public class ThirdPartyTest {
         try {
             authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
         } catch (Error e) {
-            System.out.println(e);
+            out.println(e);
             assertEquals(
                     new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
                             new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -3,7 +3,6 @@ package org.biscuitsec.biscuit.token;
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
 import org.biscuitsec.biscuit.error.Error;
-import org.biscuitsec.biscuit.error.FailedCheck;
 import org.biscuitsec.biscuit.error.FailedCheck.FailedBlock;
 import org.biscuitsec.biscuit.token.builder.Block;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import java.time.Duration;
 import java.util.List;
 
 import static java.lang.System.out;
-import static org.biscuitsec.biscuit.error.LogicError.MatchedPolicy;
 import static org.biscuitsec.biscuit.error.LogicError.MatchedPolicy.*;
 import static org.biscuitsec.biscuit.error.LogicError.Unauthorized;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -32,24 +32,24 @@ public class ThirdPartyTest {
         KeyPair external = new KeyPair(rng);
         out.println("external: ed25519/"+external.public_key().toHex());
 
-        Block authority_builder = new Block();
-        authority_builder.add_fact("right(\"read\")");
-        authority_builder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+        Block authorityBuilder = new Block();
+        authorityBuilder.add_fact("right(\"read\")");
+        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
 
-        Biscuit b1 = Biscuit.make(rng, root, authority_builder.build());
+        Biscuit b1 = Biscuit.make(rng, root, authorityBuilder.build());
         ThirdPartyBlockRequest request = b1.thirdPartyRequest();
-        byte[] reqb = request.toBytes();
-        ThirdPartyBlockRequest reqdeser = ThirdPartyBlockRequest.fromBytes(reqb);
-        assertEquals(request, reqdeser);
+        byte[] reqBytes = request.toBytes();
+        ThirdPartyBlockRequest reqDeser = ThirdPartyBlockRequest.fromBytes(reqBytes);
+        assertEquals(request, reqDeser);
 
         Block builder = new Block();
         builder.add_fact("group(\"admin\")");
         builder.add_check("check if resource(\"file1\")");
 
         ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).get();
-        byte[] resb = blockResponse.toBytes();
-        ThirdPartyBlockContents resdeser = ThirdPartyBlockContents.fromBytes(resb);
-        assertEquals(blockResponse, resdeser);
+        byte[] responseBytes = blockResponse.toBytes();
+        ThirdPartyBlockContents responseDeser = ThirdPartyBlockContents.fromBytes(responseBytes);
+        assertEquals(blockResponse, responseDeser);
 
         Biscuit b2 = b1.appendThirdPartyBlock(external.public_key(), blockResponse);
 
@@ -95,11 +95,11 @@ public class ThirdPartyTest {
         KeyPair external3 = new KeyPair(rng);
         //System.out.println("external: ed25519/"+external.public_key().toHex());
 
-        Block authority_builder = new Block();
-        authority_builder.add_fact("right(\"read\")");
-        authority_builder.add_check("check if first(\"admin\") trusting ed25519/"+external1.public_key().toHex());
+        Block authorityBuilder = new Block();
+        authorityBuilder.add_fact("right(\"read\")");
+        authorityBuilder.add_check("check if first(\"admin\") trusting ed25519/"+external1.public_key().toHex());
 
-        org.biscuitsec.biscuit.token.Block authority_block =  authority_builder.build();
+        org.biscuitsec.biscuit.token.Block authority_block =  authorityBuilder.build();
         out.println(authority_block);
         Biscuit b1 = Biscuit.make(rng, root, authority_block);
         out.println("TOKEN: "+b1.print());
@@ -139,7 +139,6 @@ public class ThirdPartyTest {
         assertEquals(b4.print(), deser4.print());
         out.println("TOKEN: "+deser4.print());
 
-
         out.println("will check the token for resource=file1");
         Authorizer authorizer = deser4.authorizer();
         authorizer.add_fact("resource(\"file1\")");
@@ -176,11 +175,11 @@ public class ThirdPartyTest {
         KeyPair external = new KeyPair(rng);
         out.println("external: ed25519/"+external.public_key().toHex());
 
-        Block authority_builder = new Block();
-        authority_builder.add_fact("right(\"read\")");
-        authority_builder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+        Block authorityBuilder = new Block();
+        authorityBuilder.add_fact("right(\"read\")");
+        authorityBuilder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
 
-        Biscuit b1 = Biscuit.make(rng, root, authority_builder.build());
+        Biscuit b1 = Biscuit.make(rng, root, authorityBuilder.build());
         ThirdPartyBlockRequest request = b1.thirdPartyRequest();
         Block builder = new Block();
         builder.add_fact("group(\"admin\")");

--- a/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
@@ -31,8 +31,8 @@ public class UnverifiedBiscuitTest {
 
         KeyPair keypair0 = new KeyPair(rng);
 
-       // org.biscuitsec.biscuit.token.builder.Block block0 = new org.biscuitsec.biscuit.token.builder.Block(0);
-       org.biscuitsec.biscuit.token.builder.Biscuit block0 = Biscuit.builder(rng, keypair0);
+        // org.biscuitsec.biscuit.token.builder.Block block0 = new org.biscuitsec.biscuit.token.builder.Block(0);
+        org.biscuitsec.biscuit.token.builder.Biscuit block0 = Biscuit.builder(rng, keypair0);
         block0.add_authority_fact(Utils.fact("right", List.of(Utils.s("file1"), Utils.s("read"))));
         block0.add_authority_fact(Utils.fact("right", List.of(Utils.s("file2"), Utils.s("read"))));
         block0.add_authority_fact(Utils.fact("right", List.of(Utils.s("file1"), Utils.s("write"))));

--- a/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -28,7 +29,7 @@ public class UnverifiedBiscuitTest {
         byte[] seed = {0, 0, 0, 0};
         SecureRandom rng = new SecureRandom(seed);
 
-        System.out.println("preparing the authority block, block0");
+        out.println("preparing the authority block, block0");
 
         KeyPair keypair0 = new KeyPair(rng);
 
@@ -41,21 +42,21 @@ public class UnverifiedBiscuitTest {
 
         Biscuit biscuit0 = block0.build();
 
-        System.out.println(biscuit0.print());
-        System.out.println("serializing the first token");
+        out.println(biscuit0.print());
+        out.println("serializing the first token");
 
         String data = biscuit0.serialize_b64url();
 
-        System.out.print("data len: ");
-        System.out.println(data.length());
-        System.out.println(data);
+        out.print("data len: ");
+        out.println(data.length());
+        out.println(data);
 
-        System.out.println("deserializing the first token");
+        out.println("deserializing the first token");
         UnverifiedBiscuit deser0 = UnverifiedBiscuit.from_b64url(data);
-        System.out.println(deser0.print());
+        out.println(deser0.print());
 
         // SECOND BLOCK
-        System.out.println("preparing the second block");
+        out.println("preparing the second block");
 
         KeyPair keypair1 = new KeyPair(rng);
         org.biscuitsec.biscuit.token.builder.Block block1 = deser0.create_block();
@@ -70,23 +71,23 @@ public class UnverifiedBiscuitTest {
         )));
         UnverifiedBiscuit unverifiedBiscuit1 = deser0.attenuate(rng, keypair1, block1.build());
 
-        System.out.println(unverifiedBiscuit1.print());
+        out.println(unverifiedBiscuit1.print());
 
-        System.out.println("serializing the second token");
+        out.println("serializing the second token");
 
         String data1 = unverifiedBiscuit1.serialize_b64url();
 
-        System.out.print("data len: ");
-        System.out.println(data1.length());
-        System.out.println(data1);
+        out.print("data len: ");
+        out.println(data1.length());
+        out.println(data1);
 
-        System.out.println("deserializing the second token");
+        out.println("deserializing the second token");
         UnverifiedBiscuit deser1 = UnverifiedBiscuit.from_b64url(data1);
 
-        System.out.println(deser1.print());
+        out.println(deser1.print());
 
         // THIRD BLOCK
-        System.out.println("preparing the third block");
+        out.println("preparing the third block");
 
         KeyPair keypair2 = new KeyPair(rng);
 
@@ -101,26 +102,26 @@ public class UnverifiedBiscuitTest {
 
         UnverifiedBiscuit unverifiedBiscuit2 = unverifiedBiscuit1.attenuate(rng, keypair2, block2);
 
-        System.out.println(unverifiedBiscuit2.print());
+        out.println(unverifiedBiscuit2.print());
 
-        System.out.println("serializing the third token");
+        out.println("serializing the third token");
 
         String data2 = unverifiedBiscuit2.serialize_b64url();
 
-        System.out.print("data len: ");
-        System.out.println(data2.length());
-        System.out.println(data2);
+        out.print("data len: ");
+        out.println(data2.length());
+        out.println(data2);
 
-        System.out.println("deserializing the third token");
+        out.println("deserializing the third token");
         UnverifiedBiscuit finalUnverifiedBiscuit = UnverifiedBiscuit.from_b64url(data2);
 
-        System.out.println(finalUnverifiedBiscuit.print());
+        out.println(finalUnverifiedBiscuit.print());
 
         // Crate Biscuit from UnverifiedBiscuit
         Biscuit finalBiscuit = finalUnverifiedBiscuit.verify(keypair0.public_key());
 
         // check
-        System.out.println("will check the token for resource=file1 and operation=read");
+        out.println("will check the token for resource=file1 and operation=read");
 
         Authorizer authorizer = finalBiscuit.authorizer();
         authorizer.add_fact("resource(\"file1\")");
@@ -128,7 +129,7 @@ public class UnverifiedBiscuitTest {
         authorizer.add_policy("allow if true");
         authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
 
-        System.out.println("will check the token for resource=file2 and operation=write");
+        out.println("will check the token for resource=file2 and operation=write");
 
         Authorizer authorizer2 = finalBiscuit.authorizer();
         authorizer2.add_fact("resource(\"file2\")");
@@ -138,7 +139,7 @@ public class UnverifiedBiscuitTest {
         try {
             authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
         } catch (Error e) {
-            System.out.println(e);
+            out.println(e);
             assertEquals(
                     new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
                             new FailedCheck.FailedBlock(1, 0, "check if resource($resource), operation(\"read\"), right($resource, \"read\")"),

--- a/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
@@ -3,8 +3,10 @@ package org.biscuitsec.biscuit.token;
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
 import org.biscuitsec.biscuit.error.Error;
-import org.biscuitsec.biscuit.error.FailedCheck;
-import org.biscuitsec.biscuit.error.LogicError;
+import org.biscuitsec.biscuit.error.Error.FailedLogic;
+import org.biscuitsec.biscuit.error.FailedCheck.FailedBlock;
+import org.biscuitsec.biscuit.error.LogicError.MatchedPolicy.Allow;
+import org.biscuitsec.biscuit.error.LogicError.Unauthorized;
 import org.biscuitsec.biscuit.token.builder.Block;
 import org.biscuitsec.biscuit.token.builder.Utils;
 import org.junit.jupiter.api.Test;
@@ -139,9 +141,9 @@ public class UnverifiedBiscuitTest {
         } catch (Error e) {
             out.println(e);
             assertEquals(
-                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
-                            new FailedCheck.FailedBlock(1, 0, "check if resource($resource), operation(\"read\"), right($resource, \"read\")"),
-                            new FailedCheck.FailedBlock(2, 0, "check if resource(\"file1\")")
+                    new FailedLogic(new Unauthorized(new Allow(0), Arrays.asList(
+                            new FailedBlock(1, 0, "check if resource($resource), operation(\"read\"), right($resource, \"read\")"),
+                            new FailedBlock(2, 0, "check if resource(\"file1\")")
                     ))),
                     e);
         }

--- a/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/UnverifiedBiscuitTest.java
@@ -2,7 +2,6 @@ package org.biscuitsec.biscuit.token;
 
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.datalog.RunLimits;
-import org.biscuitsec.biscuit.datalog.SymbolTable;
 import org.biscuitsec.biscuit.error.Error;
 import org.biscuitsec.biscuit.error.FailedCheck;
 import org.biscuitsec.biscuit.error.LogicError;
@@ -20,7 +19,6 @@ import java.util.List;
 
 import static java.lang.System.out;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class UnverifiedBiscuitTest {
 


### PR DESCRIPTION
Very trivial changes:
- Break up some large methods.
- Constently use `camelCase` method and variable naming convention for declarations within the `test` src module.
- All changes restricted to test cases;  nothing changed in `main` src module.

Partially addresses Issue #1